### PR TITLE
Hamamastu correction bug (PROBLEM-2191). Initialization of T1 was mis…

### DIFF
--- a/pom_64_Win7_shared.xml
+++ b/pom_64_Win7_shared.xml
@@ -57,8 +57,10 @@
                             <define>NDEBUG</define>
                             <define>_WINDOWS</define>
                             <define>_USRDLL</define>
-                            <define>_WIN32_WINNT=_WIN32_WINNT_WIN7</define>
-                            <define>WIN32_LEAN_AND_MEAN</define>					
+                            <!-- <define>_WIN32_WINNT=_WIN32_WINNT_WIN7</define> -->
+                            <!-- <define>WIN32_LEAN_AND_MEAN</define>					 -->
+							<define>LIMA_PROCESSCORE_DLL</define>
+							<define>LIMA_PROCESSCORE_BUILD</define>	
                         </defines>
 					</cpp>
 					<linker>

--- a/pom_64_Win7_shared.xml
+++ b/pom_64_Win7_shared.xml
@@ -59,8 +59,6 @@
                             <define>_USRDLL</define>
                             <!-- <define>_WIN32_WINNT=_WIN32_WINNT_WIN7</define> -->
                             <!-- <define>WIN32_LEAN_AND_MEAN</define>					 -->
-							<define>LIMA_PROCESSCORE_DLL</define>
-							<define>LIMA_PROCESSCORE_BUILD</define>	
                         </defines>
 					</cpp>
 					<linker>

--- a/pom_64_Win7_shared.xml
+++ b/pom_64_Win7_shared.xml
@@ -57,8 +57,8 @@
                             <define>NDEBUG</define>
                             <define>_WINDOWS</define>
                             <define>_USRDLL</define>
-                            <!-- <define>_WIN32_WINNT=_WIN32_WINNT_WIN7</define> -->
-                            <!-- <define>WIN32_LEAN_AND_MEAN</define>					 -->
+                            <define>_WIN32_WINNT=_WIN32_WINNT_WIN7</define>
+                            <define>WIN32_LEAN_AND_MEAN</define>					
                         </defines>
 					</cpp>
 					<linker>

--- a/src/HamamatsuCamera.cpp
+++ b/src/HamamatsuCamera.cpp
@@ -1707,8 +1707,8 @@ void Camera::CameraThread::execStartAcq()
 
     DCAMERR   err          = DCAMERR_NONE;
     bool      continue_acq = true        ;
-    Timestamp T0    ;
-    Timestamp T1    ;
+    Timestamp T0    = Timestamp::now();
+    Timestamp T1    = Timestamp::now();
     Timestamp DeltaT;
     long      status;
 
@@ -1972,7 +1972,7 @@ void Camera::CameraThread::execStartAcq()
 
         m_cam->m_mutex_force_stop.unlock();
         
-        // Update fps
+        // Update fps 
         T1     = Timestamp::now();
         DeltaT = T1 - T0;
 


### PR DESCRIPTION
Correction of PROBLEM-2191 (SNAP/STOP during the first frame) T1 was not initialized during the first iteration of the snap which caused a failure on the .exe