### PR TITLE
[Hamamatsu/Orca]: Analyse pour l'integration d'un nouveau modèle: QUEST

### DIFF
--- a/include/HamamatsuCamera.h
+++ b/include/HamamatsuCamera.h
@@ -59,59 +59,59 @@ namespace lima
     namespace Hamamatsu
     {
     /* 
-    // Refactoring
-    struct TRIGGER
-    {
+	// Refactoring
+	struct TRIGGER
+	{
         enum TYPE
-        {
-            INPUT=0,
-            OUTPUT=1
-        }
-        enum NAME
-        {
-            ACTIVE=0,
+	    {
+		    INPUT=0,
+		    OUTPUT=1
+	    }
+        enum IDSTR
+	    {
+		    ACTIVE=0,
             DELAY,
             KIND,
             POLARITY,
-            SOURCE
-        }
+		    SOURCE
+	    }
 
-        TRIGGER::TYPE type;
-        TRIGGER::NAME name,
-        char[32] desc;
+		TRIGGER::TYPE type;
+        TRIGGER::IDSTR id,
+		char[32] desc;
 
-        TRIGGER(TRIGGER::TYPE arg_type, TRIGGER::NAME arg_name, char* arg_desc)
-        {
-            type = arg_type;
-            name = arg_name;
-            strcpy(desc, arg_desc);
-        }
-    }
+		TRIGGER(TRIGGER::TYPE arg_type, TRIGGER::IDSTR arg_id, char* arg_desc)
+		{
+			type = arg_type;
+            id = arg_id;
+			strcpy(desc, arg_desc);
+		}
+	}
 
-    #define INPUT_TRIGGER_ACTIVE    TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::NAME::ACTIVE, "Active")
-    #define INPUT_TRIGGER_POLARITY  TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::NAME::POLARITY, "Polarity")
+    #define INPUT_TRIGGER_ACTIVE    TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::IDSTR::ACTIVE, "Active")
+    #define INPUT_TRIGGER_POLARITY  TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::IDSTR::POLARITY, "Polarity")
 
-    #define OUTPUT_TRIGGER_DELAY    TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::DELAY, "Delay")
-    #define OUTPUT_TRIGGER_SOURCE   TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::SOURCE, "Source")
-    #define OUTPUT_TRIGGER_KIND     TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::KIND, "Kind")
-    #define OUTPUT_TRIGGER_POLARITY TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::POLARITY, "Polarity")
+    #define OUTPUT_TRIGGER_DELAY    TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::IDSTR::DELAY, "Delay")
+    #define OUTPUT_TRIGGER_SOURCE   TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::IDSTR::SOURCE, "Source")
+    #define OUTPUT_TRIGGER_KIND     TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::IDSTR::KIND, "Kind")
+    #define OUTPUT_TRIGGER_POLARITY TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::IDSTR::POLARITY, "Polarity")
     */
 
 /*******************************************************************
  * \class Camera
  * \brief object controlling the Hamamatsu camera via DCAM-SDK
  *******************************************************************/
-    class LIBHAMAMATSU_API Camera
-    {
-        DEB_CLASS_NAMESPC(DebModCamera, "Camera", "Hamamatsu");
-        friend class Interface;
+	class LIBHAMAMATSU_API Camera
+	{
+	    DEB_CLASS_NAMESPC(DebModCamera, "Camera", "Hamamatsu");
+	    friend class Interface;
 
     //-----------------------------------------------------------------------------
-    public:
-        enum Status 
+	public:
+	    enum Status 
         {
-            Ready, Exposure, Readout, Latency, Fault
-        };
+		    Ready, Exposure, Readout, Latency, Fault
+	    };
 
         typedef std::map<TrigMode, bool> trigOptionsMap;
 
@@ -175,16 +175,16 @@ namespace lima
         // Pixel Type
         enum Pixel_Type
         {
-            Pixel_Type_Not_Supported = 0,
+			Pixel_Type_Not_Supported = 0,
             Pixel_Type_Mono8    , // DCAM_PIXELTYPE_MONO8
             Pixel_Type_Mono16   , // DCAM_PIXELTYPE_MONO16
-            Pixel_Type_RGB24    , // DCAM_PIXELTYPE_RGB24
-            Pixel_Type_RGB48    , // DCAM_PIXELTYPE_RGB48
+			Pixel_Type_RGB24    , // DCAM_PIXELTYPE_RGB24
+			Pixel_Type_RGB48    , // DCAM_PIXELTYPE_RGB48
             Pixel_Type_BGR24    , // DCAM_PIXELTYPE_BGR24
-            Pixel_Type_BGR48      // DCAM_PIXELTYPE_BGR48
+            Pixel_Type_BGR48 	  // DCAM_PIXELTYPE_BGR48
         };
 
-        // Sensor Mode
+        // Scan Mode
         enum Scan_Mode
         {
             Scan_Mode_Not_Supported = 0   ,
@@ -196,28 +196,28 @@ namespace lima
         enum Input_Trigger_Active
         {
             Input_Trigger_Active_Not_Supported  ,
-            Input_Trigger_Active_Edge           , // DCAMPROP_TRIGGERACTIVE__EDGE           
-            Input_Trigger_Active_Level          , // DCAMPROP_TRIGGERACTIVE__LEVEL      
-            Input_Trigger_Active_SyncReadout      // DCAMPROP_TRIGGERACTIVE__SYNCREADOUT    
+            Input_Trigger_Active_Edge           , // DCAMPROP_TRIGGERACTIVE__EDGE			
+            Input_Trigger_Active_Level          , // DCAMPROP_TRIGGERACTIVE__LEVEL		
+            Input_Trigger_Active_SyncReadout      // DCAMPROP_TRIGGERACTIVE__SYNCREADOUT	
         };
 
         // relative to DCAM_IDPROP_TRIGGER_POLARITY
         enum Input_Trigger_Polarity
         {
             Input_Trigger_Polarity_Not_Supported  ,
-            Input_Trigger_Polarity_Negative       , // DCAMPROP_TRIGGERPOLARITY__NEGATIVE           
-            Input_Trigger_Polarity_Positive         // DCAMPROP_TRIGGERPOLARITY__POSITIVE       
+            Input_Trigger_Polarity_Negative       , // DCAMPROP_TRIGGERPOLARITY__NEGATIVE			
+            Input_Trigger_Polarity_Positive         // DCAMPROP_TRIGGERPOLARITY__POSITIVE		
         };
 
         // relative to DCAM_IDPROP_OUTPUTTRIGGER_KIND
         enum Output_Trigger_Kind
         {
             Output_Trigger_Kind_Not_Supported       ,
-            Output_Trigger_Kind_Low                 , // DCAMPROP_OUTPUTTRIGGER_KIND__LOW           
-            Output_Trigger_Kind_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_KIND__EXPOSURE      
-            Output_Trigger_Kind_Programmable        , // DCAMPROP_OUTPUTTRIGGER_KIND__PROGRAMABLE   
-            Output_Trigger_Kind_TriggerReady        , // DCAMPROP_OUTPUTTRIGGER_KIND__TRIGGERREADY  
-            Output_Trigger_Kind_High                  // DCAMPROP_OUTPUTTRIGGER_KIND__HIGH          //Not yet available with current SDK
+            Output_Trigger_Kind_Low                 , // DCAMPROP_OUTPUTTRIGGER_KIND__LOW			
+            Output_Trigger_Kind_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_KIND__EXPOSURE		
+            Output_Trigger_Kind_Programmable        , // DCAMPROP_OUTPUTTRIGGER_KIND__PROGRAMABLE	
+            Output_Trigger_Kind_TriggerReady        , // DCAMPROP_OUTPUTTRIGGER_KIND__TRIGGERREADY	
+            Output_Trigger_Kind_High                  // DCAMPROP_OUTPUTTRIGGER_KIND__HIGH			//Not yet available with current SDK
 
         };
 
@@ -233,75 +233,75 @@ namespace lima
         enum Output_Trigger_Source
         {
             Output_Trigger_Source_Not_Supported       ,
-            Output_Trigger_Source_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE          
-            Output_Trigger_Source_Readout_End         , // DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND        
-            Output_Trigger_Source_VSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC 
-            Output_Trigger_Source_HSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC 
-            Output_Trigger_Source_Trigger               // DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER           // Aavailable with ORCA QUEST
+            Output_Trigger_Source_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE			
+            Output_Trigger_Source_Readout_End         , // DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND		
+            Output_Trigger_Source_VSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC	
+            Output_Trigger_Source_HSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC	
+            Output_Trigger_Source_Trigger               // DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER			// Aavailable with ORCA QUEST
         };
 
-    //-----------------------------------------------------------------------------
-    public:
-        Camera(const std::string& config_path,int camera_number=0, int frame_buffer_size=10);
-        ~Camera();
+	//-----------------------------------------------------------------------------
+	public:
+	    Camera(const std::string& config_path,int camera_number=0, int frame_buffer_size=10);
+	    ~Camera();
 
-        void startAcq();
-        void stopAcq();
-        void prepareAcq();
+	    void startAcq();
+	    void stopAcq();
+		void prepareAcq();
     
-        // -- detector info object
-        void getImageType(ImageType& type);
-        void setImageType(ImageType type);
+	    // -- detector info object
+	    void getImageType(ImageType& type);
+	    void setImageType(ImageType type);
 
-        void getDetectorType(std::string& type);
-        void getDetectorModel(std::string& model);
-        void getDetectorImageSize(Size& size);
-        void getDetectorMaxImageSize(Size& size);
+	    void getDetectorType(std::string& type);
+	    void getDetectorModel(std::string& model);
+	    void getDetectorImageSize(Size& size);
+		void getDetectorMaxImageSize(Size& size);
     
-        // -- Buffer control object
-        HwBufferCtrlObj* getBufferCtrlObj();
+	    // -- Buffer control object
+	    HwBufferCtrlObj* getBufferCtrlObj();
         HwEventCtrlObj * getEventCtrlObj ();
     
-        //-- Synch control object
-        bool checkTrigMode(TrigMode trig_mode);
-        void setTrigMode(TrigMode  mode);
-        void getTrigMode(TrigMode& mode);
+	    //-- Synch control object
+	    bool checkTrigMode(TrigMode trig_mode);
+	    void setTrigMode(TrigMode  mode);
+	    void getTrigMode(TrigMode& mode);
     
-        void setExpTime(double  exp_time);
-        void getExpTime(double& exp_time);
+	    void setExpTime(double  exp_time);
+	    void getExpTime(double& exp_time);
 
-        void setLatTime(double  lat_time);
-        void getLatTime(double& lat_time);
+	    void setLatTime(double  lat_time);
+	    void getLatTime(double& lat_time);
 
-        void getExposureTimeRange(double& min_expo, double& max_expo) const;
-        void getLatTimeRange(double& min_lat, double& max_lat) const;    
+	    void getExposureTimeRange(double& min_expo, double& max_expo) const;
+	    void getLatTimeRange(double& min_lat, double& max_lat) const;    
 
-        void setNbFrames(int  nb_frames);
-        void getNbFrames(int& nb_frames);
-        void getNbHwAcquiredFrames(int &nb_acq_frames);
+	    void setNbFrames(int  nb_frames);
+	    void getNbFrames(int& nb_frames);
+	    void getNbHwAcquiredFrames(int &nb_acq_frames);
 
-        void checkRoi(const Roi& set_roi, Roi& hw_roi);
-        void setRoi(const Roi& set_roi);
-        void getRoi(Roi& hw_roi);    
+	    void checkRoi(const Roi& set_roi, Roi& hw_roi);
+	    void setRoi(const Roi& set_roi);
+	    void getRoi(Roi& hw_roi);    
 
-        void checkBin(Bin&);
-        void setBin(const Bin&);
-        void getBin(Bin&);
-        bool isBinningAvailable();       
+	    void checkBin(Bin&);
+	    void setBin(const Bin&);
+	    void getBin(Bin&);
+	    bool isBinningAvailable();       
 
-        void getPixelSize(double& sizex, double& sizey);
+	    void getPixelSize(double& sizex, double& sizey);
     
-        Camera::Status getStatus();
+	    Camera::Status getStatus();
     
-        void reset();
+	    void reset();
 
-        // -- Hamamatsu specific
-        long HamamatsuError(string& strErr);
-        void initialiseController();
-        void setFastExtTrigger(bool flag);
-        void getFastExtTrigger(bool& flag);
-        void getLostFrames(unsigned long int& lost_frames); ///< [out] current lost frames
-        void getFPS(double& fps);                           ///< [out] last computed fps
+	    // -- Hamamatsu specific
+	    long HamamatsuError(string& strErr);
+	    void initialiseController();
+	    void setFastExtTrigger(bool flag);
+	    void getFastExtTrigger(bool& flag);
+		void getLostFrames(unsigned long int& lost_frames);	///< [out] current lost frames
+		void getFPS(double& fps);							///< [out] last computed fps
    
         void setSyncReadoutBlankMode(enum SyncReadOut_BlankMode in_sync_read_out_mode); ///< [in] type of sync-readout trigger's blank
 
@@ -332,9 +332,9 @@ namespace lima
         //void setChannelTrigger(int channel, int trigger_enum, TRIGGER trigger);
 
         // ICATHALES-587
-        // Get number of channels
-        long getNbMaxChannels(int32 idProp=-1);
-        
+		// Get number of channels
+		long getNbMaxChannels(int32 idProp=-1);
+		
         //-- Input Triggers  control is channel independant
         enum Camera::Input_Trigger_Active getInputTriggerActive(); ///< [in] channel to get
         enum Camera::Input_Trigger_Polarity getInputTriggerPolarity(); ///< [in] channel to get
@@ -348,7 +348,7 @@ namespace lima
         void setOutputTriggerKind(int channel,                                                          ///< [in] channel to set
                                   enum Camera::Output_Trigger_Kind in_output_trig_kind);                ///< [in] kind of the channel to set
         void setOutputTriggerSource(int in_channel,                                                     ///< [in] the channel to set
-                                    enum Camera::Output_Trigger_Source in_output_trig_source);          ///< [in] source of the channel to set
+                                    enum Camera::Output_Trigger_Source in_output_trig_source, bool raise_ex=true);          ///< [in] source of the channel to set
         void setOutputTriggerPolarity(int in_channel,                                                   ///< [in] the channel to set
                                       enum Camera::Output_Trigger_Polarity in_output_trig_polarity);    ///< [in] polarity of the channel to set
 
@@ -360,12 +360,9 @@ namespace lima
         // Sensor Mode
         enum Camera::Sensor_Mode getSensorMode(); ///< [in] channel to get
         void setSensorMode(enum Sensor_Mode in_sensor_mode);
-        
-        enum Camera::Pixel_Type getPixelType();
-        void setPixelType(enum Pixel_Type in_pixel_type);
-
-        enum Camera::Scan_Mode getScanMode();
-        void setScanMode(enum Scan_Mode in_scan_mode);
+		
+		enum Camera::Pixel_Type getPixelType();
+		void setPixelType(enum Pixel_Type in_pixel_type);
 
         void traceAllRoi(void);
         void checkingROIproperties(void);
@@ -410,9 +407,9 @@ namespace lima
         void initParametersMap();
         void mapIdParameter(int32 parameter_id);
 
-        bool isOrcaQuest();
-        
-    private:
+		bool isOrcaQuest();
+		
+	private:
         void initDetectorModel();
         void initialiseOrcaQuest();
 
@@ -426,7 +423,7 @@ namespace lima
         std::string getCoolerStatusLabelFromStatus(enum Camera::Cooler_Status in_cooler_status);
 
         short int getReadoutSpeed(void) const;
-        void      setReadoutSpeed(const short int readout_speed); ///< [in]  new readout speed
+		void      setReadoutSpeed(const short int readout_speed); ///< [in]  new readout speed
 
         std::string getReadoutSpeedLabelFromValue(const short int in_readout_speed) const;
         short int   getReadoutSpeedFromLabel     (const std::string & in_readout_speed_label) const;
@@ -442,52 +439,52 @@ namespace lima
 
         
 
-    //-----------------------------------------------------------------------------
-    private:
-        //-----------------------------------------------------------------------------
+	//-----------------------------------------------------------------------------
+	private:
+		//-----------------------------------------------------------------------------
         // CameraThread class
-        //-----------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------
         class CameraThread: public CmdThread
-        {
-            DEB_CLASS_NAMESPC(DebModCamera, "CameraThread", "Hamamatsu");
-        public:
-            // Status
+		{
+			DEB_CLASS_NAMESPC(DebModCamera, "CameraThread", "Hamamatsu");
+		public:
+			// Status
             enum
-            { 
-                Ready    = MaxThreadStatus, 
+			{ 
+				Ready    = MaxThreadStatus, 
                 Exposure                  , 
                 Readout                   , 
                 Latency                   ,
                 Fault                     ,
-            };
+			};
 
-            // Cmd
+			// Cmd
             enum
-            { 
-                StartAcq = MaxThreadCmd, 
-            };
+			{ 
+				StartAcq = MaxThreadCmd, 
+			};
 
-            CameraThread(Camera * cam);
+			CameraThread(Camera * cam);
 
             // destructor
             virtual ~CameraThread();
 
-            virtual void start();
+			virtual void start();
             virtual void abort();
 
             void abortCapture(void);
-            volatile bool m_force_stop;
+			volatile bool m_force_stop;
 
-        protected:
-            virtual void init   ();
-            virtual void execCmd(int cmd);
+		protected:
+			virtual void init   ();
+			virtual void execCmd(int cmd);
             
-        private:
-            void execStartAcq();
+		private:
+			void execStartAcq();
 
-            bool copyFrames(const int index_frame_begin,    ///< [in] index of the frame where to begin copy
-                            const int nb_frames_count  ,    ///< [in] number of frames to copy
-                            StdBufferCbMgr& buffer_mgr );   ///< [in] buffer manager object
+            bool copyFrames(const int index_frame_begin,	///< [in] index of the frame where to begin copy
+							const int nb_frames_count  ,	///< [in] number of frames to copy
+							StdBufferCbMgr& buffer_mgr );	///< [in] buffer manager object
 
             void checkStatusBeforeCapturing() const;
 
@@ -497,20 +494,20 @@ namespace lima
             void getTransfertInfo(int32 & frame_index,
                                   int32 & frame_count);
 
-            Camera*   m_cam        ;
+			Camera*   m_cam        ;
             HDCAMWAIT m_wait_handle;
 
-        };
-        friend class CameraThread;
+		};
+		friend class CameraThread;
 
-        //-----------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------
         // Feature class used to get data informations of a property 
-        //-----------------------------------------------------------------------------
-        class FeatureInfos
-        {
-            DEB_CLASS_NAMESPC(DebModCamera, "FeatureInfos", "Hamamatsu");
+		//-----------------------------------------------------------------------------
+		class FeatureInfos
+		{
+			DEB_CLASS_NAMESPC(DebModCamera, "FeatureInfos", "Hamamatsu");
 
-            friend class Camera; // Camera class can access directly to private attributs like if they were public declared
+    		friend class Camera; // Camera class can access directly to private attributs like if they were public declared
 
         public:
             FeatureInfos();
@@ -522,9 +519,9 @@ namespace lima
 
             void RoundValue(int & inout_value)  const;
 
-        private:
-            string         m_name             ; ///< name of the feature    
-            double         m_min              ; ///< min value of the feature   
+		private:
+            string         m_name             ; ///< name of the feature	
+            double         m_min              ; ///< min value of the feature	
             double         m_max              ; ///< max value of the feature
             double         m_step             ; ///< minimum stepping between a value and the next
             double         m_default_value    ; ///< default value of the feature
@@ -538,13 +535,13 @@ namespace lima
             bool           m_is_readable      ; ///< is readable ?
             bool           m_has_view         ; ///< has view ?
             bool           m_has_auto_rounding; ///< has auto rounding ?
-            int32          m_max_view         ; ///< max view if supported
+            int32 		   m_max_view         ; ///< max view if supported
         };
 
-        //-----------------------------------------------------------------------------
-        // DCAM-SDK Helper
-        //-----------------------------------------------------------------------------
-        // TRACE METHODS
+		//-----------------------------------------------------------------------------
+		// DCAM-SDK Helper
+		//-----------------------------------------------------------------------------
+		// TRACE METHODS
         static std::string string_format_arg(const char* format, va_list args);
         static std::string string_format    (const char* format, ...);
 
@@ -586,7 +583,7 @@ namespace lima
                                                         va_list            args     ,  ///< [in] optional args (printf style) to merge with the opt string (NULL if not used)
                                                         bool               is_error ); ///< [in] true if traced like an error, false for a classic info trace
 
-        //-----------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------
         void   execStopAcq();
 
         void   showCameraInfo      (HDCAM hd_cam); ///< [in] camera device id
@@ -601,18 +598,18 @@ namespace lima
                                        long  height   ,  ///< [in] vertical size
                                        int   view_index); ///< [in] View index [0...max view[. Use g_get_sub_array_do_not_use_view for general subarray 
 
-        bool   dcamex_getsubarrayrect( HDCAM   hd_cam    ,  ///< [in] camera handle
-                                       int32 & left     ,  ///< [in] left  (x)
-                                       int32 & top      ,  ///< [in] top   (y)
-                                       int32 & width    ,  ///< [in] horizontal size
-                                       int32 & height   ,  ///< [in] vertical size
+		bool   dcamex_getsubarrayrect( HDCAM   hd_cam    ,  ///< [in] camera handle
+									   int32 & left     ,  ///< [in] left  (x)
+									   int32 & top      ,  ///< [in] top   (y)
+									   int32 & width    ,  ///< [in] horizontal size
+									   int32 & height   ,  ///< [in] vertical size
                                        int     view_index); ///< [in] View index [0...max view[. Use -1 for general subarray 
 
-        long   dcamex_getimagewidth (const HDCAM hd_cam ); ///< [in] camera handle
-        
-        long   dcamex_getimageheight(const HDCAM hd_cam ); ///< [in] camera handle
+		long   dcamex_getimagewidth (const HDCAM hd_cam ); ///< [in] camera handle
+		
+		long   dcamex_getimageheight(const HDCAM hd_cam ); ///< [in] camera handle
 
-        long   dcamex_getbitsperchannel( HDCAM hd_cam );    ///< [in] camera handle
+		long   dcamex_getbitsperchannel( HDCAM hd_cam );    ///< [in] camera handle
 
         void   dcamex_setimagepixeltype( HDCAM hd_cam   ,  ///< [in] camera handle
                                         int   pixel_type); ///< [in] pixel type
@@ -620,7 +617,7 @@ namespace lima
         bool   dcamex_getfeatureinq( HDCAM          hd_cam      ,        ///< [in ] camera handle
                                      const string   feature_name,        ///< [in ] feature name
                                      long           id_feature  ,        ///< [in ] feature id
-                                     FeatureInfos & feature_obj ) const; ///< [out] feature informations class  
+                                     FeatureInfos & feature_obj ) const; ///< [out] feature informations class	
 
         bool dcamex_getpropertyvalues( HDCAM            hd_cam     ,        ///< [in ] camera handle
                                        DCAMPROP_ATTR    attr       ,        ///< [in ] attribut which contains the array base
@@ -642,60 +639,60 @@ namespace lima
 
         void setTriggerPolarity(enum Trigger_Polarity in_trigger_polarity) const; ///< [in] type of trigger polarity
 
-        // DCAM-SDK Helper end
-        bool  isBinningSupported(const int   bin_value); /// Check if a binning value is supported
+		// DCAM-SDK Helper end
+		bool  isBinningSupported(const int   bin_value); /// Check if a binning value is supported
         int32 GetBinningMode    (const int   bin_value); ///< [in] binning value to chck for
-        int   GetBinningFromMode(const int32 bin_mode );    ///< [in] binning mode to chck for
+        int   GetBinningFromMode(const int32 bin_mode );	///< [in] binning mode to chck for
 
-        vector<int> m_vectBinnings; /// list of available binning modes
-        
-        //-----------------------------------------------------------------------------
-        //- lima stuff
-        SoftBufferCtrlObj           m_buffer_ctrl_obj;
+		vector<int> m_vectBinnings; /// list of available binning modes
+		
+		//-----------------------------------------------------------------------------
+	    //- lima stuff
+	    SoftBufferCtrlObj	        m_buffer_ctrl_obj;
         HwEventCtrlObj              m_event_ctrl_obj ;
-        int                         m_nb_frames      ;    
-        Camera::Status              m_status         ;
-        int                         m_image_number   ;
-        int                         m_timeout        ;
-        double                      m_latency_time   ;
-        Roi                         m_roi            ; /// current roi parameters
-        Bin                         m_bin            ; /// current binning paramenters
-        Bin                         m_bin_max        ; /// maximum bining parameters
-        TrigMode                    m_trig_mode      ;
-        map<int, string>            m_map_triggerMode;
+	    int                         m_nb_frames      ;    
+	    Camera::Status              m_status         ;
+	    int                         m_image_number   ;
+	    int                         m_timeout        ;
+	    double                      m_latency_time   ;
+	    Roi                         m_roi            ; /// current roi parameters
+	    Bin                         m_bin            ; /// current binning paramenters
+	    Bin                         m_bin_max        ; /// maximum bining parameters
+	    TrigMode                    m_trig_mode      ;
+		map<int, string>			m_map_triggerMode;
         std::map<string, int>            m_map_parameters ;
 
-        // Specific
-        unsigned int long           m_lost_frames_count;
-        double                      m_fps              ;
+		// Specific
+		unsigned int long			m_lost_frames_count;
+		double						m_fps              ;
       
-        //- camera stuff 
-        string                      m_detector_model;
-        string                      m_detector_type ;
-        long                        m_depth         ;
+	    //- camera stuff 
+	    string                      m_detector_model;
+	    string                      m_detector_type ;
+		long						m_depth         ;
         long                        m_bytes_per_pixel;
-        long                        m_max_image_width, m_max_image_height;
+		long						m_max_image_width, m_max_image_height;
     
-        //- Hamamatsu SDK stuff
-        string                      m_config_path        ;
-        int                         m_camera_number      ;
-        HDCAM                       m_camera_handle      ;
-        DWORD                       m_camera_capabilities;
-        string                      m_camera_error_str   ;
-        int                         m_camera_error       ;
+	    //- Hamamatsu SDK stuff
+	    string                      m_config_path        ;
+	    int                         m_camera_number      ;
+	    HDCAM						m_camera_handle      ;
+	    DWORD				        m_camera_capabilities;
+	    string                      m_camera_error_str   ;
+	    int                         m_camera_error       ;
         int                         m_frame_buffer_size  ; // number of images in the DCAM internal buffer 
-           
-        bool                        m_fasttrigger        ; // ?
-        int                         m_temperature_sp     ;   
-        int                         m_read_mode          ;
-        int                         m_acq_mode           ;  
-        double                      m_exp_time           ;
-        double                      m_exp_time_max       ;
+    	   
+	    bool                        m_fasttrigger        ; // ?
+	    int                         m_temperature_sp     ;   
+	    int                         m_read_mode          ;
+	    int                         m_acq_mode           ;  
+	    double                      m_exp_time           ;
+	    double                      m_exp_time_max       ;
 
-        CameraThread                m_thread             ;
-        Mutex                       m_mutex_force_stop   ;
+		CameraThread 				m_thread             ;
+		Mutex						m_mutex_force_stop   ;
 
-        trigOptionsMap              m_map_trig_modes     ;
+	    trigOptionsMap              m_map_trig_modes     ;
 
         FeatureInfos                m_feature_pos_x      ; // property data to check the ROI
         FeatureInfos                m_feature_pos_y      ; // property data to check the ROI
@@ -706,20 +703,20 @@ namespace lima
         bool                        m_view_mode_enabled  ; // W-View mode with splitting image
         int                         m_view_number        ; // number of W-Views
         int                         m_max_views          ; // maximum number of views for this camera (if > 1 then W-View mode is supported) 
-        double                    * m_view_exp_time      ; // array of exposure value by view
+	    double                    * m_view_exp_time      ; // array of exposure value by view
 
         bool                        m_hdr_enabled        ; // high dynamic range activation latest value
 
-        //-----------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------
         // Constants
-        //-----------------------------------------------------------------------------
+		//-----------------------------------------------------------------------------
         static const double g_orca_pixel_size              ;
         static const int    g_dcam_str_msg_size            ;
         static const int    g_get_sub_array_do_not_use_view;
 
         static const string g_trace_line_separator       ;
         static const string g_trace_little_line_separator;
-    };
+	};
     } // namespace Hamamatsu
 } // namespace lima
 

--- a/include/HamamatsuCamera.h
+++ b/include/HamamatsuCamera.h
@@ -58,22 +58,60 @@ namespace lima
 {
     namespace Hamamatsu
     {
+    /* 
+    // Refactoring
+    struct TRIGGER
+    {
+        enum TYPE
+        {
+            INPUT=0,
+            OUTPUT=1
+        }
+        enum NAME
+        {
+            ACTIVE=0,
+            DELAY,
+            KIND,
+            POLARITY,
+            SOURCE
+        }
+
+        TRIGGER::TYPE type;
+        TRIGGER::NAME name,
+        char[32] desc;
+
+        TRIGGER(TRIGGER::TYPE arg_type, TRIGGER::NAME arg_name, char* arg_desc)
+        {
+            type = arg_type;
+            name = arg_name;
+            strcpy(desc, arg_desc);
+        }
+    }
+
+    #define INPUT_TRIGGER_ACTIVE    TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::NAME::ACTIVE, "Active")
+    #define INPUT_TRIGGER_POLARITY  TRIGGER(TRIGGER::TYPE::INPUT, TRIGGER::NAME::POLARITY, "Polarity")
+
+    #define OUTPUT_TRIGGER_DELAY    TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::DELAY, "Delay")
+    #define OUTPUT_TRIGGER_SOURCE   TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::SOURCE, "Source")
+    #define OUTPUT_TRIGGER_KIND     TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::KIND, "Kind")
+    #define OUTPUT_TRIGGER_POLARITY TRIGGER(TRIGGER::TYPE::OUTPUT, TRIGGER::NAME::POLARITY, "Polarity")
+    */
 
 /*******************************************************************
  * \class Camera
  * \brief object controlling the Hamamatsu camera via DCAM-SDK
  *******************************************************************/
-	class LIBHAMAMATSU_API Camera
-	{
-	    DEB_CLASS_NAMESPC(DebModCamera, "Camera", "Hamamatsu");
-	    friend class Interface;
+    class LIBHAMAMATSU_API Camera
+    {
+        DEB_CLASS_NAMESPC(DebModCamera, "Camera", "Hamamatsu");
+        friend class Interface;
 
     //-----------------------------------------------------------------------------
-	public:
-	    enum Status 
+    public:
+        enum Status 
         {
-		    Ready, Exposure, Readout, Latency, Fault
-	    };
+            Ready, Exposure, Readout, Latency, Fault
+        };
 
         typedef std::map<TrigMode, bool> trigOptionsMap;
 
@@ -123,15 +161,63 @@ namespace lima
             Cooler_Status_Warning      , // DCAMPROP_SENSORCOOLERSTATUS__WARNING
         };
 
+        // Sensor Mode
+        enum Sensor_Mode
+        {
+            Sensor_Mode_Not_Supported = 0,
+            Sensor_Mode_Area            , // DCAMPROP_SENSORMODE__AREA
+            Sensor_Mode_Line            , // DCAMPROP_SENSORMODE__LINE
+            Sensor_Mode_TDI             , // DCAMPROP_SENSORMODE__TDI
+            Sensor_Mode_TDI_Extented    , // DCAMPROP_SENSORMODE__TDI_EXTENDED
+            Sensor_Mode_Progressive     , // DCAMPROP_SENSORMODE__PROGRESSIVE
+        };
+
+        // Pixel Type
+        enum Pixel_Type
+        {
+            Pixel_Type_Not_Supported = 0,
+            Pixel_Type_Mono8    , // DCAM_PIXELTYPE_MONO8
+            Pixel_Type_Mono16   , // DCAM_PIXELTYPE_MONO16
+            Pixel_Type_RGB24    , // DCAM_PIXELTYPE_RGB24
+            Pixel_Type_RGB48    , // DCAM_PIXELTYPE_RGB48
+            Pixel_Type_BGR24    , // DCAM_PIXELTYPE_BGR24
+            Pixel_Type_BGR48      // DCAM_PIXELTYPE_BGR48
+        };
+
+        // Sensor Mode
+        enum Scan_Mode
+        {
+            Scan_Mode_Not_Supported = 0   ,
+            Scan_Mode_Ultra_Quiet         , // DCAMPROP_READOUTSPEED__SLOWEST
+            Scan_Mode_Standard            , // DCAMPROP_READOUTSPEED__FASTEST
+        };
+
+        // relative to DCAM_IDPROP_TRIGGER_ACTIVE
+        enum Input_Trigger_Active
+        {
+            Input_Trigger_Active_Not_Supported  ,
+            Input_Trigger_Active_Edge           , // DCAMPROP_TRIGGERACTIVE__EDGE           
+            Input_Trigger_Active_Level          , // DCAMPROP_TRIGGERACTIVE__LEVEL      
+            Input_Trigger_Active_SyncReadout      // DCAMPROP_TRIGGERACTIVE__SYNCREADOUT    
+        };
+
+        // relative to DCAM_IDPROP_TRIGGER_POLARITY
+        enum Input_Trigger_Polarity
+        {
+            Input_Trigger_Polarity_Not_Supported  ,
+            Input_Trigger_Polarity_Negative       , // DCAMPROP_TRIGGERPOLARITY__NEGATIVE           
+            Input_Trigger_Polarity_Positive         // DCAMPROP_TRIGGERPOLARITY__POSITIVE       
+        };
+
         // relative to DCAM_IDPROP_OUTPUTTRIGGER_KIND
         enum Output_Trigger_Kind
         {
             Output_Trigger_Kind_Not_Supported       ,
-            Output_Trigger_Kind_Low                 , // DCAMPROP_OUTPUTTRIGGER_KIND__LOW			
-            Output_Trigger_Kind_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_KIND__EXPOSURE		
-            Output_Trigger_Kind_Programmable        , // DCAMPROP_OUTPUTTRIGGER_KIND__PROGRAMABLE	
-            Output_Trigger_Kind_TriggerReady        , // DCAMPROP_OUTPUTTRIGGER_KIND__TRIGGERREADY	
-            Output_Trigger_Kind_High                , // DCAMPROP_OUTPUTTRIGGER_KIND__HIGH			//Not yet available with current SDK
+            Output_Trigger_Kind_Low                 , // DCAMPROP_OUTPUTTRIGGER_KIND__LOW           
+            Output_Trigger_Kind_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_KIND__EXPOSURE      
+            Output_Trigger_Kind_Programmable        , // DCAMPROP_OUTPUTTRIGGER_KIND__PROGRAMABLE   
+            Output_Trigger_Kind_TriggerReady        , // DCAMPROP_OUTPUTTRIGGER_KIND__TRIGGERREADY  
+            Output_Trigger_Kind_High                  // DCAMPROP_OUTPUTTRIGGER_KIND__HIGH          //Not yet available with current SDK
 
         };
 
@@ -139,72 +225,83 @@ namespace lima
         enum Output_Trigger_Polarity
         {
             Output_Trigger_Polarity_Not_Supported, 
-            Output_Trigger_Polarity_Negative, // DCAMPROP_OUTPUTTRIGGER_POLARITY__NEGATIVE
-            Output_Trigger_Polarity_Positive, // DCAMPROP_OUTPUTTRIGGER_POLARITY__POSITIVE
+            Output_Trigger_Polarity_Negative     , // DCAMPROP_OUTPUTTRIGGER_POLARITY__NEGATIVE
+            Output_Trigger_Polarity_Positive      // DCAMPROP_OUTPUTTRIGGER_POLARITY__POSITIVE
         };
 
-	//-----------------------------------------------------------------------------
-	public:
-	    Camera(const std::string& config_path,int camera_number=0, int frame_buffer_size=10);
-	    ~Camera();
+        // relative to DCAM_IDPROP_OUTPUTTRIGGER_KIND
+        enum Output_Trigger_Source
+        {
+            Output_Trigger_Source_Not_Supported       ,
+            Output_Trigger_Source_Global_Exposure     , // DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE          
+            Output_Trigger_Source_Readout_End         , // DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND        
+            Output_Trigger_Source_VSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC 
+            Output_Trigger_Source_HSync               , // DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC 
+            Output_Trigger_Source_Trigger               // DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER           // Aavailable with ORCA QUEST
+        };
 
-	    void startAcq();
-	    void stopAcq();
-		void prepareAcq();
-    
-	    // -- detector info object
-	    void getImageType(ImageType& type);
-	    void setImageType(ImageType type);
+    //-----------------------------------------------------------------------------
+    public:
+        Camera(const std::string& config_path,int camera_number=0, int frame_buffer_size=10);
+        ~Camera();
 
-	    void getDetectorType(std::string& type);
-	    void getDetectorModel(std::string& model);
-	    void getDetectorImageSize(Size& size);
-		void getDetectorMaxImageSize(Size& size);
+        void startAcq();
+        void stopAcq();
+        void prepareAcq();
     
-	    // -- Buffer control object
-	    HwBufferCtrlObj* getBufferCtrlObj();
+        // -- detector info object
+        void getImageType(ImageType& type);
+        void setImageType(ImageType type);
+
+        void getDetectorType(std::string& type);
+        void getDetectorModel(std::string& model);
+        void getDetectorImageSize(Size& size);
+        void getDetectorMaxImageSize(Size& size);
+    
+        // -- Buffer control object
+        HwBufferCtrlObj* getBufferCtrlObj();
         HwEventCtrlObj * getEventCtrlObj ();
     
-	    //-- Synch control object
-	    bool checkTrigMode(TrigMode trig_mode);
-	    void setTrigMode(TrigMode  mode);
-	    void getTrigMode(TrigMode& mode);
+        //-- Synch control object
+        bool checkTrigMode(TrigMode trig_mode);
+        void setTrigMode(TrigMode  mode);
+        void getTrigMode(TrigMode& mode);
     
-	    void setExpTime(double  exp_time);
-	    void getExpTime(double& exp_time);
+        void setExpTime(double  exp_time);
+        void getExpTime(double& exp_time);
 
-	    void setLatTime(double  lat_time);
-	    void getLatTime(double& lat_time);
+        void setLatTime(double  lat_time);
+        void getLatTime(double& lat_time);
 
-	    void getExposureTimeRange(double& min_expo, double& max_expo) const;
-	    void getLatTimeRange(double& min_lat, double& max_lat) const;    
+        void getExposureTimeRange(double& min_expo, double& max_expo) const;
+        void getLatTimeRange(double& min_lat, double& max_lat) const;    
 
-	    void setNbFrames(int  nb_frames);
-	    void getNbFrames(int& nb_frames);
-	    void getNbHwAcquiredFrames(int &nb_acq_frames);
+        void setNbFrames(int  nb_frames);
+        void getNbFrames(int& nb_frames);
+        void getNbHwAcquiredFrames(int &nb_acq_frames);
 
-	    void checkRoi(const Roi& set_roi, Roi& hw_roi);
-	    void setRoi(const Roi& set_roi);
-	    void getRoi(Roi& hw_roi);    
+        void checkRoi(const Roi& set_roi, Roi& hw_roi);
+        void setRoi(const Roi& set_roi);
+        void getRoi(Roi& hw_roi);    
 
-	    void checkBin(Bin&);
-	    void setBin(const Bin&);
-	    void getBin(Bin&);
-	    bool isBinningAvailable();       
+        void checkBin(Bin&);
+        void setBin(const Bin&);
+        void getBin(Bin&);
+        bool isBinningAvailable();       
 
-	    void getPixelSize(double& sizex, double& sizey);
+        void getPixelSize(double& sizex, double& sizey);
     
-	    Camera::Status getStatus();
+        Camera::Status getStatus();
     
-	    void reset();
+        void reset();
 
-	    // -- Hamamatsu specific
-	    long HamamatsuError(string& strErr);
-	    void initialiseController();
-	    void setFastExtTrigger(bool flag);
-	    void getFastExtTrigger(bool& flag);
-		void getLostFrames(unsigned long int& lost_frames);	///< [out] current lost frames
-		void getFPS(double& fps);							///< [out] last computed fps
+        // -- Hamamatsu specific
+        long HamamatsuError(string& strErr);
+        void initialiseController();
+        void setFastExtTrigger(bool flag);
+        void getFastExtTrigger(bool& flag);
+        void getLostFrames(unsigned long int& lost_frames); ///< [out] current lost frames
+        void getFPS(double& fps);                           ///< [out] last computed fps
    
         void setSyncReadoutBlankMode(enum SyncReadOut_BlankMode in_sync_read_out_mode); ///< [in] type of sync-readout trigger's blank
 
@@ -229,13 +326,46 @@ namespace lima
         void setViewMode(bool in_view_mode_activated,  ///< [in] view mode activation or not
                          int  in_views_number       ); ///< [in] number of views if view mode activated
 
-        //-- Output Triggers  control
-        void setOutputTriggerKind    (int channel,                                                   ///< [in] channel to set
-                                      enum Camera::Output_Trigger_Kind in_output_trig_kind);                 ///< [in] kind of the channel to set
-        void setOutputTriggerPolarity(int in_channel,                                                ///< [in] the channel to set
-                                      enum Camera::Output_Trigger_Polarity in_output_trig_polarity); ///< [in] polarity of the channel to set
-        enum Camera::Output_Trigger_Kind getOutputTriggerKind(int channel); ///< [in] channel to get
+        // ICATHALES-587
+        // Refactoring
+        //int getChannelTrigger(int channel, TRIGGER trigger);
+        //void setChannelTrigger(int channel, int trigger_enum, TRIGGER trigger);
+
+        // ICATHALES-587
+        // Get number of channels
+        long getNbMaxChannels(int32 idProp=-1);
+        
+        //-- Input Triggers  control is channel independant
+        enum Camera::Input_Trigger_Active getInputTriggerActive(); ///< [in] channel to get
+        enum Camera::Input_Trigger_Polarity getInputTriggerPolarity(); ///< [in] channel to get
+
+        void setInputTriggerActive(enum Input_Trigger_Active in_input_trig_active);
+        void setInputTriggerPolarity(enum Input_Trigger_Polarity in_input_trig_polarity);
+
+        //-- Output Triggers  control is channel dependant
+        void setOutputTriggerDelay(int channel,                                                         ///< [in] channel to set
+                                   double in_output_trig_delay);                                        ///< [in] delay of the channel to set
+        void setOutputTriggerKind(int channel,                                                          ///< [in] channel to set
+                                  enum Camera::Output_Trigger_Kind in_output_trig_kind);                ///< [in] kind of the channel to set
+        void setOutputTriggerSource(int in_channel,                                                     ///< [in] the channel to set
+                                    enum Camera::Output_Trigger_Source in_output_trig_source);          ///< [in] source of the channel to set
+        void setOutputTriggerPolarity(int in_channel,                                                   ///< [in] the channel to set
+                                      enum Camera::Output_Trigger_Polarity in_output_trig_polarity);    ///< [in] polarity of the channel to set
+
+        double getOutputTriggerDelay(int channel);                                  ///< [in] channel to get
+        enum Camera::Output_Trigger_Kind getOutputTriggerKind(int channel);         ///< [in] channel to get
+        enum Camera::Output_Trigger_Source getOutputTriggerSource(int channel);     ///< [in] channel to get
         enum Camera::Output_Trigger_Polarity getOutputTriggerPolarity(int channel); ///< [in] channel to get
+
+        // Sensor Mode
+        enum Camera::Sensor_Mode getSensorMode(); ///< [in] channel to get
+        void setSensorMode(enum Sensor_Mode in_sensor_mode);
+        
+        enum Camera::Pixel_Type getPixelType();
+        void setPixelType(enum Pixel_Type in_pixel_type);
+
+        enum Camera::Scan_Mode getScanMode();
+        void setScanMode(enum Scan_Mode in_scan_mode);
 
         void traceAllRoi(void);
         void checkingROIproperties(void);
@@ -280,7 +410,12 @@ namespace lima
         void initParametersMap();
         void mapIdParameter(int32 parameter_id);
 
-	private:
+        bool isOrcaQuest();
+        
+    private:
+        void initDetectorModel();
+        void initialiseOrcaQuest();
+
         enum Camera::Cooler_Mode getCoolerMode(void);
         std::string getCoolerModeLabelFromMode(enum Camera::Cooler_Mode in_cooler_mode);
 
@@ -291,7 +426,7 @@ namespace lima
         std::string getCoolerStatusLabelFromStatus(enum Camera::Cooler_Status in_cooler_status);
 
         short int getReadoutSpeed(void) const;
-		void      setReadoutSpeed(const short int readout_speed); ///< [in]  new readout speed
+        void      setReadoutSpeed(const short int readout_speed); ///< [in]  new readout speed
 
         std::string getReadoutSpeedLabelFromValue(const short int in_readout_speed) const;
         short int   getReadoutSpeedFromLabel     (const std::string & in_readout_speed_label) const;
@@ -307,52 +442,52 @@ namespace lima
 
         
 
-	//-----------------------------------------------------------------------------
-	private:
-		//-----------------------------------------------------------------------------
+    //-----------------------------------------------------------------------------
+    private:
+        //-----------------------------------------------------------------------------
         // CameraThread class
-		//-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         class CameraThread: public CmdThread
-		{
-			DEB_CLASS_NAMESPC(DebModCamera, "CameraThread", "Hamamatsu");
-		public:
-			// Status
+        {
+            DEB_CLASS_NAMESPC(DebModCamera, "CameraThread", "Hamamatsu");
+        public:
+            // Status
             enum
-			{ 
-				Ready    = MaxThreadStatus, 
+            { 
+                Ready    = MaxThreadStatus, 
                 Exposure                  , 
                 Readout                   , 
                 Latency                   ,
                 Fault                     ,
-			};
+            };
 
-			// Cmd
+            // Cmd
             enum
-			{ 
-				StartAcq = MaxThreadCmd, 
-			};
+            { 
+                StartAcq = MaxThreadCmd, 
+            };
 
-			CameraThread(Camera * cam);
+            CameraThread(Camera * cam);
 
             // destructor
             virtual ~CameraThread();
 
-			virtual void start();
+            virtual void start();
             virtual void abort();
 
             void abortCapture(void);
-			volatile bool m_force_stop;
+            volatile bool m_force_stop;
 
-		protected:
-			virtual void init   ();
-			virtual void execCmd(int cmd);
+        protected:
+            virtual void init   ();
+            virtual void execCmd(int cmd);
             
-		private:
-			void execStartAcq();
+        private:
+            void execStartAcq();
 
-            bool copyFrames(const int index_frame_begin,	///< [in] index of the frame where to begin copy
-							const int nb_frames_count  ,	///< [in] number of frames to copy
-							StdBufferCbMgr& buffer_mgr );	///< [in] buffer manager object
+            bool copyFrames(const int index_frame_begin,    ///< [in] index of the frame where to begin copy
+                            const int nb_frames_count  ,    ///< [in] number of frames to copy
+                            StdBufferCbMgr& buffer_mgr );   ///< [in] buffer manager object
 
             void checkStatusBeforeCapturing() const;
 
@@ -362,20 +497,20 @@ namespace lima
             void getTransfertInfo(int32 & frame_index,
                                   int32 & frame_count);
 
-			Camera*   m_cam        ;
+            Camera*   m_cam        ;
             HDCAMWAIT m_wait_handle;
 
-		};
-		friend class CameraThread;
+        };
+        friend class CameraThread;
 
-		//-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         // Feature class used to get data informations of a property 
-		//-----------------------------------------------------------------------------
-		class FeatureInfos
-		{
-			DEB_CLASS_NAMESPC(DebModCamera, "FeatureInfos", "Hamamatsu");
+        //-----------------------------------------------------------------------------
+        class FeatureInfos
+        {
+            DEB_CLASS_NAMESPC(DebModCamera, "FeatureInfos", "Hamamatsu");
 
-    		friend class Camera; // Camera class can access directly to private attributs like if they were public declared
+            friend class Camera; // Camera class can access directly to private attributs like if they were public declared
 
         public:
             FeatureInfos();
@@ -387,9 +522,9 @@ namespace lima
 
             void RoundValue(int & inout_value)  const;
 
-		private:
-            string         m_name             ; ///< name of the feature	
-            double         m_min              ; ///< min value of the feature	
+        private:
+            string         m_name             ; ///< name of the feature    
+            double         m_min              ; ///< min value of the feature   
             double         m_max              ; ///< max value of the feature
             double         m_step             ; ///< minimum stepping between a value and the next
             double         m_default_value    ; ///< default value of the feature
@@ -403,13 +538,13 @@ namespace lima
             bool           m_is_readable      ; ///< is readable ?
             bool           m_has_view         ; ///< has view ?
             bool           m_has_auto_rounding; ///< has auto rounding ?
-            int32 		   m_max_view         ; ///< max view if supported
+            int32          m_max_view         ; ///< max view if supported
         };
 
-		//-----------------------------------------------------------------------------
-		// DCAM-SDK Helper
-		//-----------------------------------------------------------------------------
-		// TRACE METHODS
+        //-----------------------------------------------------------------------------
+        // DCAM-SDK Helper
+        //-----------------------------------------------------------------------------
+        // TRACE METHODS
         static std::string string_format_arg(const char* format, va_list args);
         static std::string string_format    (const char* format, ...);
 
@@ -451,7 +586,7 @@ namespace lima
                                                         va_list            args     ,  ///< [in] optional args (printf style) to merge with the opt string (NULL if not used)
                                                         bool               is_error ); ///< [in] true if traced like an error, false for a classic info trace
 
-		//-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         void   execStopAcq();
 
         void   showCameraInfo      (HDCAM hd_cam); ///< [in] camera device id
@@ -466,18 +601,18 @@ namespace lima
                                        long  height   ,  ///< [in] vertical size
                                        int   view_index); ///< [in] View index [0...max view[. Use g_get_sub_array_do_not_use_view for general subarray 
 
-		bool   dcamex_getsubarrayrect( HDCAM   hd_cam    ,  ///< [in] camera handle
-									   int32 & left     ,  ///< [in] left  (x)
-									   int32 & top      ,  ///< [in] top   (y)
-									   int32 & width    ,  ///< [in] horizontal size
-									   int32 & height   ,  ///< [in] vertical size
+        bool   dcamex_getsubarrayrect( HDCAM   hd_cam    ,  ///< [in] camera handle
+                                       int32 & left     ,  ///< [in] left  (x)
+                                       int32 & top      ,  ///< [in] top   (y)
+                                       int32 & width    ,  ///< [in] horizontal size
+                                       int32 & height   ,  ///< [in] vertical size
                                        int     view_index); ///< [in] View index [0...max view[. Use -1 for general subarray 
 
-		long   dcamex_getimagewidth (const HDCAM hd_cam ); ///< [in] camera handle
-		
-		long   dcamex_getimageheight(const HDCAM hd_cam ); ///< [in] camera handle
+        long   dcamex_getimagewidth (const HDCAM hd_cam ); ///< [in] camera handle
+        
+        long   dcamex_getimageheight(const HDCAM hd_cam ); ///< [in] camera handle
 
-		long   dcamex_getbitsperchannel( HDCAM hd_cam );    ///< [in] camera handle
+        long   dcamex_getbitsperchannel( HDCAM hd_cam );    ///< [in] camera handle
 
         void   dcamex_setimagepixeltype( HDCAM hd_cam   ,  ///< [in] camera handle
                                         int   pixel_type); ///< [in] pixel type
@@ -485,7 +620,7 @@ namespace lima
         bool   dcamex_getfeatureinq( HDCAM          hd_cam      ,        ///< [in ] camera handle
                                      const string   feature_name,        ///< [in ] feature name
                                      long           id_feature  ,        ///< [in ] feature id
-                                     FeatureInfos & feature_obj ) const; ///< [out] feature informations class	
+                                     FeatureInfos & feature_obj ) const; ///< [out] feature informations class  
 
         bool dcamex_getpropertyvalues( HDCAM            hd_cam     ,        ///< [in ] camera handle
                                        DCAMPROP_ATTR    attr       ,        ///< [in ] attribut which contains the array base
@@ -507,60 +642,60 @@ namespace lima
 
         void setTriggerPolarity(enum Trigger_Polarity in_trigger_polarity) const; ///< [in] type of trigger polarity
 
-		// DCAM-SDK Helper end
-		bool  isBinningSupported(const int   bin_value); /// Check if a binning value is supported
+        // DCAM-SDK Helper end
+        bool  isBinningSupported(const int   bin_value); /// Check if a binning value is supported
         int32 GetBinningMode    (const int   bin_value); ///< [in] binning value to chck for
-        int   GetBinningFromMode(const int32 bin_mode );	///< [in] binning mode to chck for
+        int   GetBinningFromMode(const int32 bin_mode );    ///< [in] binning mode to chck for
 
-		vector<int> m_vectBinnings; /// list of available binning modes
-		
-		//-----------------------------------------------------------------------------
-	    //- lima stuff
-	    SoftBufferCtrlObj	        m_buffer_ctrl_obj;
+        vector<int> m_vectBinnings; /// list of available binning modes
+        
+        //-----------------------------------------------------------------------------
+        //- lima stuff
+        SoftBufferCtrlObj           m_buffer_ctrl_obj;
         HwEventCtrlObj              m_event_ctrl_obj ;
-	    int                         m_nb_frames      ;    
-	    Camera::Status              m_status         ;
-	    int                         m_image_number   ;
-	    int                         m_timeout        ;
-	    double                      m_latency_time   ;
-	    Roi                         m_roi            ; /// current roi parameters
-	    Bin                         m_bin            ; /// current binning paramenters
-	    Bin                         m_bin_max        ; /// maximum bining parameters
-	    TrigMode                    m_trig_mode      ;
-		map<int, string>			m_map_triggerMode;
+        int                         m_nb_frames      ;    
+        Camera::Status              m_status         ;
+        int                         m_image_number   ;
+        int                         m_timeout        ;
+        double                      m_latency_time   ;
+        Roi                         m_roi            ; /// current roi parameters
+        Bin                         m_bin            ; /// current binning paramenters
+        Bin                         m_bin_max        ; /// maximum bining parameters
+        TrigMode                    m_trig_mode      ;
+        map<int, string>            m_map_triggerMode;
         std::map<string, int>            m_map_parameters ;
 
-		// Specific
-		unsigned int long			m_lost_frames_count;
-		double						m_fps              ;
+        // Specific
+        unsigned int long           m_lost_frames_count;
+        double                      m_fps              ;
       
-	    //- camera stuff 
-	    string                      m_detector_model;
-	    string                      m_detector_type ;
-		long						m_depth         ;
+        //- camera stuff 
+        string                      m_detector_model;
+        string                      m_detector_type ;
+        long                        m_depth         ;
         long                        m_bytes_per_pixel;
-		long						m_max_image_width, m_max_image_height;
+        long                        m_max_image_width, m_max_image_height;
     
-	    //- Hamamatsu SDK stuff
-	    string                      m_config_path        ;
-	    int                         m_camera_number      ;
-	    HDCAM						m_camera_handle      ;
-	    DWORD				        m_camera_capabilities;
-	    string                      m_camera_error_str   ;
-	    int                         m_camera_error       ;
+        //- Hamamatsu SDK stuff
+        string                      m_config_path        ;
+        int                         m_camera_number      ;
+        HDCAM                       m_camera_handle      ;
+        DWORD                       m_camera_capabilities;
+        string                      m_camera_error_str   ;
+        int                         m_camera_error       ;
         int                         m_frame_buffer_size  ; // number of images in the DCAM internal buffer 
-    	   
-	    bool                        m_fasttrigger        ; // ?
-	    int                         m_temperature_sp     ;   
-	    int                         m_read_mode          ;
-	    int                         m_acq_mode           ;  
-	    double                      m_exp_time           ;
-	    double                      m_exp_time_max       ;
+           
+        bool                        m_fasttrigger        ; // ?
+        int                         m_temperature_sp     ;   
+        int                         m_read_mode          ;
+        int                         m_acq_mode           ;  
+        double                      m_exp_time           ;
+        double                      m_exp_time_max       ;
 
-		CameraThread 				m_thread             ;
-		Mutex						m_mutex_force_stop   ;
+        CameraThread                m_thread             ;
+        Mutex                       m_mutex_force_stop   ;
 
-	    trigOptionsMap              m_map_trig_modes     ;
+        trigOptionsMap              m_map_trig_modes     ;
 
         FeatureInfos                m_feature_pos_x      ; // property data to check the ROI
         FeatureInfos                m_feature_pos_y      ; // property data to check the ROI
@@ -571,20 +706,20 @@ namespace lima
         bool                        m_view_mode_enabled  ; // W-View mode with splitting image
         int                         m_view_number        ; // number of W-Views
         int                         m_max_views          ; // maximum number of views for this camera (if > 1 then W-View mode is supported) 
-	    double                    * m_view_exp_time      ; // array of exposure value by view
+        double                    * m_view_exp_time      ; // array of exposure value by view
 
         bool                        m_hdr_enabled        ; // high dynamic range activation latest value
 
-		//-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         // Constants
-		//-----------------------------------------------------------------------------
+        //-----------------------------------------------------------------------------
         static const double g_orca_pixel_size              ;
         static const int    g_dcam_str_msg_size            ;
         static const int    g_get_sub_array_do_not_use_view;
 
         static const string g_trace_line_separator       ;
         static const string g_trace_little_line_separator;
-	};
+    };
     } // namespace Hamamatsu
 } // namespace lima
 

--- a/src/HamamatsuCamera.cpp
+++ b/src/HamamatsuCamera.cpp
@@ -73,6 +73,7 @@ const string Camera::g_trace_little_line_separator = "--------------------------
 #define READOUTSPEED_SLOW_NAME      "SLOW"
 #define READOUTSPEED_NORMAL_NAME    "NORMAL"
 
+#define ORCA_QUEST                  "C15550-20UP"
 //-----------------------------------------------------------------------------
 ///  Ctor
 //-----------------------------------------------------------------------------
@@ -102,6 +103,7 @@ Camera::Camera(const std::string& config_path, int camera_number, int frame_buff
     m_config_path       = config_path  ;
     m_camera_number     = camera_number;
     m_frame_buffer_size = frame_buffer_size;
+    m_detector_model = "";
   
     m_map_triggerMode[IntTrig       ] = "IntTrig"       ;
     m_map_triggerMode[IntTrigMult   ] = "IntTrigMult"   ;
@@ -115,72 +117,78 @@ Camera::Camera(const std::string& config_path, int camera_number, int frame_buff
     // --- Get available cameras and select the choosen one.    
     m_camera_handle = dcam_init_open(camera_number);
 
-    if (NULL != m_camera_handle)
-    {
-        // --- Initialise deeper parameters of the controller                
-        initialiseController();
-
-        // retrying the maximum number of views for this camera
-        // Will be also used to know if W-View mode is possible
-        m_max_views = getMaxNumberofViews();
-        
-        if(m_max_views > 1)
-        {
-            m_view_exp_time = new double[m_max_views];
-
-            for(int view_index = 0 ; view_index < m_max_views ; view_index++)
-            {
-                m_view_exp_time[view_index] = m_exp_time; // by default
-            }
-        }
-        else
-        {
-            m_view_exp_time = NULL;
-        }
-
-        // --- BIN already set to 1,1 above.
-        // --- Hamamatsu sets the ROI by starting coordinates at 1 and not 0 !!!!
-        Size size_max;
-        getDetectorImageSize(size_max);
-        Roi a_roi = Roi(0,0, size_max.getWidth(), size_max.getHeight());
-
-        // Store max image size
-        m_max_image_width  = size_max.getWidth ();
-        m_max_image_height = size_max.getHeight();
-
-        // Display max image size
-        DEB_TRACE() << "Detector max width: " << m_max_image_width ;
-        DEB_TRACE() << "Detector max height:" << m_max_image_height;
-
-        // sets no view mode by default
-        m_view_mode_enabled = false; // W-View mode with splitting image
-        m_view_number      = 0    ; // number of W-Views
-
-        setViewMode(false, 0);
-
-        // --- setRoi applies both bin and roi
-        DEB_TRACE() << "Set the ROI to full frame: "<< a_roi;
-        setRoi(a_roi);        
-        
-        // --- Get the maximum exposure time allowed and set default
-        setExpTime(m_exp_time);
-        
-        // --- Set detector for software single image mode    
-        setTrigMode(IntTrig);
-        
-        m_nb_frames = 1;
-
-        // --- Initialize the map of the camera parameters
-        initParametersMap();
-
-        // --- finally start the acq thread
-        m_thread.start();
-    }
-    else
+    if (NULL == m_camera_handle)
     {
         manage_error( deb, "Unable to initialize the camera (Check if it is already ON or if another software is currently using it).");
         THROW_HW_ERROR(Error) << "Unable to initialize the camera (Check if it is already ON or if another software is currently using it).";
     }
+    
+    // ICATHALES-587
+    initDetectorModel();
+
+    // --- Initialise deeper parameters of the controller                
+    initialiseController();
+
+    if (isOrcaQuest())
+    {
+        initialiseOrcaQuest();
+    }
+
+    // retrying the maximum number of views for this camera
+    // Will be also used to know if W-View mode is possible
+    m_max_views = getMaxNumberofViews();
+    
+    if(m_max_views > 1)
+    {
+        m_view_exp_time = new double[m_max_views];
+
+        for(int view_index = 0 ; view_index < m_max_views ; view_index++)
+        {
+            m_view_exp_time[view_index] = m_exp_time; // by default
+        }
+    }
+    else
+    {
+        m_view_exp_time = NULL;
+    }
+
+    // --- BIN already set to 1,1 above.
+    // --- Hamamatsu sets the ROI by starting coordinates at 1 and not 0 !!!!
+    Size size_max;
+    getDetectorImageSize(size_max);
+    Roi a_roi = Roi(0,0, size_max.getWidth(), size_max.getHeight());
+
+    // Store max image size
+    m_max_image_width  = size_max.getWidth ();
+    m_max_image_height = size_max.getHeight();
+
+    // Display max image size
+    DEB_TRACE() << "Detector max width: " << m_max_image_width ;
+    DEB_TRACE() << "Detector max height:" << m_max_image_height;
+
+    // sets no view mode by default
+    m_view_mode_enabled = false; // W-View mode with splitting image
+    m_view_number      = 0    ; // number of W-Views
+
+    setViewMode(false, 0);
+
+    // --- setRoi applies both bin and roi
+    DEB_TRACE() << "Set the ROI to full frame: "<< a_roi;
+    setRoi(a_roi);        
+    
+    // --- Get the maximum exposure time allowed and set default
+    setExpTime(m_exp_time);
+    
+    // --- Set detector for software single image mode    
+    setTrigMode(IntTrig);
+    
+    m_nb_frames = 1;
+
+    // --- Initialize the map of the camera parameters
+    initParametersMap();
+
+    // --- finally start the acq thread
+    m_thread.start();
 }
 
 //-----------------------------------------------------------------------------
@@ -219,6 +227,33 @@ Camera::~Camera()
         delete [] m_view_exp_time;
 
     DEB_TRACE() << "Camera destructor done.";
+}
+
+// ICATHALES-587
+void Camera::initDetectorModel()
+{
+    DEB_MEMBER_FUNCT();
+    
+    char model_str[MAX_PATH];
+    DCAMERR err;
+
+    DCAMDEV_STRING  param;
+    memset( &param, 0, sizeof(param) );
+    param.size      = sizeof(param);
+    param.text      = model_str;
+    param.textbytes = sizeof(model_str);
+    param.iString   = DCAM_IDSTR_MODEL;
+    
+    err = dcamdev_getstring( m_camera_handle, &param );
+    if (failed(err))
+    {
+        manage_error(deb, "Cannot get detector model", err, "dcamdev_getstring", "IDSTR=DCAM_IDSTR_MODEL");
+    }
+    else
+    {
+        m_detector_model = model_str;
+        DEB_TRACE() << "m_detector_model = " << m_detector_model;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -274,6 +309,7 @@ void Camera::getImageType(ImageType& type)
         switch( bits_type )
         {
             case 8 :  type = Bpp8 ; break;
+            case 12:  type = Bpp12; break;
             case 16:  type = Bpp16; break;
             case 32:  type = Bpp32; break;
             default:
@@ -299,19 +335,38 @@ void Camera::setImageType(ImageType type)
     DEB_TRACE() << "Camera::setImageType - " << DEB_VAR1(type);
     switch(type)
     {
+        case Bpp8:
+        {
+            m_depth    = 8;
+            m_bytes_per_pixel = 1;
+            break;
+        }
+        case Bpp12:
+        {
+            m_depth    = 12;
+            m_bytes_per_pixel = 2;
+            break;
+        }
         case Bpp16:
         {
             m_depth    = 16;
+            m_bytes_per_pixel = 2;
+            break;
+        }
+        case Bpp32:
+        {
+            m_depth    = 32;
+            m_bytes_per_pixel = 4;
             break;
         }
         default:
-            manage_error( deb, "This pixel format of the camera is not managed, only 16 bits cameras are already managed!");
-            THROW_HW_ERROR(Error) << "This pixel format of the camera is not managed, only 16 bits cameras are already managed!";
+            manage_error( deb, "This pixel format of the camera is not managed, only 16, 12 and 8 bits cameras are already managed!");
+            THROW_HW_ERROR(Error) << "This pixel format of the camera is not managed, only 16, 12 AND 8 bits cameras are already managed!";
             break;
     }
 
     DEB_TRACE() << "SetImageType: " << m_depth;
-    m_bytes_per_pixel = m_depth / 8;
+    //m_bytes_per_pixel = m_depth / 8;
 }
 
 //-----------------------------------------------------------------------------
@@ -1049,6 +1104,14 @@ void Camera::reset()
     return;
 }
 
+bool Camera::isOrcaQuest()
+{
+    std::string model = m_detector_model;
+    transform(model.begin(), model.end(), model.begin(), ::toupper);
+    std::size_t pos = model.find("C15550-20UP");
+    return pos != std::string::npos;
+}
+
 //-----------------------------------------------------------------------------
 ///    initialise controller with speeds and preamp gain
 //-----------------------------------------------------------------------------
@@ -1235,6 +1298,81 @@ void Camera::initialiseController()
 }
 
 //-----------------------------------------------------------------------------
+///    initialise controller with speeds and preamp gain
+//-----------------------------------------------------------------------------
+
+void Camera::initialiseOrcaQuest()
+{
+    DEB_MEMBER_FUNCT();
+
+    //---------------------------------------------------------------------
+    // Create the list of available trigger modes from camera capabilities
+    // inputtrigger active
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    FeatureInfos inputtrigger_active_feature_obj;   
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_TRIGGERACTIVE", DCAM_IDPROP_TRIGGERACTIVE, inputtrigger_active_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get inputtrigger active modes");
+        THROW_HW_ERROR(Error) << "Failed to get inputtrigger active modes";
+    }
+    inputtrigger_active_feature_obj.traceModePossibleValues();
+
+    //---------------------------------------------------------------------
+    // Create the list of available trigger modes from camera capabilities
+    // inputtrigger polarity
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    FeatureInfos inputtrigger_polarity_feature_obj;   
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_TRIGGERPOLARITY", DCAM_IDPROP_TRIGGERPOLARITY, inputtrigger_polarity_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get inputtrigger polarity modes");
+        THROW_HW_ERROR(Error) << "Failed to get inputtrigger polarity modes";
+    }
+    inputtrigger_polarity_feature_obj.traceModePossibleValues();
+
+    // Output triggers
+    FeatureInfos outputtrigger_delay_feature_obj;
+    FeatureInfos outputtrigger_source_feature_obj;
+    FeatureInfos outputtrigger_kind_feature_obj;
+    FeatureInfos outputtrigger_polarity_feature_obj;
+
+    // outputtrigger delay
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_OUTPUTTRIGGER_DELAY", DCAM_IDPROP_OUTPUTTRIGGER_DELAY, outputtrigger_delay_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get outputtrigger delay modes");
+        THROW_HW_ERROR(Error) << "Failed to get outputtrigger delay modes";
+    }
+    outputtrigger_delay_feature_obj.traceModePossibleValues();
+
+    // outputtrigger source
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_OUTPUTTRIGGER_SOURCE", DCAM_IDPROP_OUTPUTTRIGGER_SOURCE, outputtrigger_source_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get outputtrigger source modes");
+        THROW_HW_ERROR(Error) << "Failed to get outputtrigger source modes";
+    }
+    outputtrigger_source_feature_obj.traceModePossibleValues();
+
+    // outputtrigger kind
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_OUTPUTTRIGGER_KIND", DCAM_IDPROP_OUTPUTTRIGGER_KIND, outputtrigger_kind_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get outputtrigger kind modes");
+        THROW_HW_ERROR(Error) << "Failed to get outputtrigger kind modes";
+    }
+    outputtrigger_kind_feature_obj.traceModePossibleValues();
+
+    // outputtrigger polarity
+    DEB_TRACE() << g_trace_line_separator.c_str();
+    if( !dcamex_getfeatureinq( m_camera_handle, "DCAM_IDPROP_OUTPUTTRIGGER_POLARITY", DCAM_IDPROP_OUTPUTTRIGGER_POLARITY, outputtrigger_polarity_feature_obj ) )
+    {
+        manage_error( deb, "Failed to get outputtrigger polarity modes");
+        THROW_HW_ERROR(Error) << "Failed to get outputtrigger polarity modes";
+    }
+    outputtrigger_polarity_feature_obj.traceModePossibleValues();
+}
+
+//-----------------------------------------------------------------------------
 /// Get the dcamdsk trigger mode value associated to the given Lima TrigMode 
 /*!
 sets dcamdsk trigger option with its property.
@@ -1323,7 +1461,7 @@ short int Camera::getReadoutSpeed(void) const
     DEB_MEMBER_FUNCT();
 
     DCAMERR err   ;
-    int32   read_mode = 0  ;
+    short   read_mode = 0  ;
     double  v  =   0.0;
 
     err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_READOUTSPEED, &v );
@@ -1334,10 +1472,10 @@ short int Camera::getReadoutSpeed(void) const
     }
     else    
     {
-        read_mode = static_cast<int32>(v);
+        read_mode = static_cast<short>(v);
     }
 
-    DEB_TRACE() << DEB_VAR1(read_mode);
+    //DEB_TRACE() << DEB_VAR1(read_mode);
 
     return  read_mode;
 }
@@ -1369,7 +1507,7 @@ short int Camera::getReadoutSpeedFromLabel(const std::string & in_readout_speed_
     short int   readout_speed = READOUTSPEED_NORMAL_VALUE;
     std::string label         = in_readout_speed_label;
 
-	transform(label.begin(), label.end(), label.begin(), ::toupper);
+    transform(label.begin(), label.end(), label.begin(), ::toupper);
 
     if (label == READOUTSPEED_NORMAL_NAME)
     {
@@ -1381,11 +1519,11 @@ short int Camera::getReadoutSpeedFromLabel(const std::string & in_readout_speed_
         readout_speed = READOUTSPEED_SLOW_VALUE;
     }
     else
-	{			
-		string user_msg;
+    {           
+        string user_msg;
         user_msg = string("Available Readout speeds are:\n- ") + string(READOUTSPEED_NORMAL_NAME) + string("\n- ") + string(READOUTSPEED_SLOW_NAME);
         THROW_HW_ERROR(Error) << user_msg.c_str();
-	}
+    }
 
     return readout_speed;
 }
@@ -2616,10 +2754,10 @@ double Camera::getSensorTemperature(void)
             THROW_HW_ERROR(Error) << "Unable to retrieve the sensor temperature";
         }
     }    
-    else
+    /*else
     {
         DEB_TRACE() << DEB_VAR1(temperature);
-    }
+    }*/
     
     return temperature;
 }
@@ -2662,7 +2800,7 @@ enum Camera::Cooler_Mode Camera::getCoolerMode(void)
     {
         int32 nMode = static_cast<int32>(temp);
 
-        DEB_TRACE() << DEB_VAR1(nMode);
+        //DEB_TRACE() << DEB_VAR1(nMode);
 
         switch (nMode)
         {
@@ -2741,7 +2879,7 @@ enum Camera::Temperature_Status Camera::getTemperatureStatus(void)
     {
         int32 nMode = static_cast<int32>(temp);
 
-        DEB_TRACE() << DEB_VAR1(nMode);
+        //DEB_TRACE() << DEB_VAR1(nMode);
 
         switch (nMode)
         {
@@ -2847,7 +2985,7 @@ enum Camera::Cooler_Status Camera::getCoolerStatus(void)
     {
         int32 nMode = static_cast<int32>(temp);
 
-        DEB_TRACE() << DEB_VAR1(nMode);
+        //DEB_TRACE() << DEB_VAR1(nMode);
 
         switch (nMode)
         {
@@ -2999,6 +3137,626 @@ HwEventCtrlObj* Camera::getEventCtrlObj()
     return &m_event_ctrl_obj;
 }
 
+/*************************************************************************
+// ICATHALES-587
+*************************************************************************/
+// get property attribute
+long Camera::getNbMaxChannels(int32 idProp)
+{
+    DEB_MEMBER_FUNCT();
+    
+    long nbOfChannels = 1;
+    // get property attribute
+    DCAMPROP_ATTR   basepropattr;
+    memset( &basepropattr, 0, sizeof(basepropattr) );
+    basepropattr.cbSize = sizeof(basepropattr);
+    
+    if (idProp == -1)
+        basepropattr.iProp = DCAM_IDPROP__CHANNEL;
+    else
+        basepropattr.iProp = idProp;
+    
+    DCAMERR err;
+    err = dcamprop_getattr( m_camera_handle, &basepropattr );
+    if( !failed(err) )
+    {
+        nbOfChannels = basepropattr.nMaxChannel;
+        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : Number of channels = " << nbOfChannels;
+        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_ArrayBase = " << basepropattr.iProp_ArrayBase;
+        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_NumberOfElement = " << basepropattr.iProp_NumberOfElement;
+    }
+    else
+    {
+        manage_trace( deb, "Unable to get attr number of channels", err, "dcamprop_getattr - DCAM_IDPROP__CHANNEL");
+    }
+    return nbOfChannels;
+}
+
+// Sensor Mode
+//-----------------------------------------------------------------------------
+/// This property allows you to get the sensor mode of the camera. 
+//-----------------------------------------------------------------------------
+enum Camera::Sensor_Mode Camera::getSensorMode()
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    double  temp;
+    Camera::Sensor_Mode sensor_mode = Camera::Sensor_Mode::Sensor_Mode_Not_Supported;
+    
+    if(getStatus() == CameraThread::Ready)
+    {
+        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_SENSORMODE, &temp );      
+        if( failed(err) )
+        {
+            manage_trace( deb, "Unable to retrieve the sensor mode", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
+
+            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
+            {
+                THROW_HW_ERROR(Error) << "Unable to retrieve the sensor mode";
+            }
+        }    
+        else
+        {
+            int mode = static_cast<int>(temp);
+            switch(mode)
+            {
+                case DCAMPROP_SENSORMODE__AREA          : sensor_mode = Sensor_Mode_Area            ; break;
+                case DCAMPROP_SENSORMODE__LINE          : sensor_mode = Sensor_Mode_Line            ; break;
+                case DCAMPROP_SENSORMODE__TDI           : sensor_mode = Sensor_Mode_TDI             ; break;
+                case DCAMPROP_SENSORMODE__TDI_EXTENDED  : sensor_mode = Sensor_Mode_TDI_Extented    ; break;
+                case DCAMPROP_SENSORMODE__PROGRESSIVE   : sensor_mode = Sensor_Mode_Progressive     ; break;
+                default:
+                    manage_trace( deb, "The read sensor mode is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
+            }
+        }
+    }
+    return sensor_mode;
+}
+
+//-----------------------------------------------------------------------------
+/// This property allows you to specify the sensor mode of the camera.
+/// Mode PNR (Photon Number Resolving) not found.
+//-----------------------------------------------------------------------------
+void Camera::setSensorMode(enum Sensor_Mode in_sensor_mode)
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    double temp;
+    switch(in_sensor_mode)
+    {
+        case Sensor_Mode_Area         : temp = static_cast<double>(DCAMPROP_SENSORMODE__AREA)            ; break;
+        case Sensor_Mode_Line         : temp = static_cast<double>(DCAMPROP_SENSORMODE__LINE)            ; break;
+        case Sensor_Mode_TDI          : temp = static_cast<double>(DCAMPROP_SENSORMODE__TDI)             ; break;
+        case Sensor_Mode_TDI_Extented : temp = static_cast<double>(DCAMPROP_SENSORMODE__TDI_EXTENDED)    ; break;
+        case Sensor_Mode_Progressive  : temp = static_cast<double>(DCAMPROP_SENSORMODE__PROGRESSIVE)     ; break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the sensor mode",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_sensor_mode is unknown %d",
+                                static_cast<int>(in_sensor_mode));
+
+            THROW_HW_ERROR(Error) << "Unable to set the sensor mode";
+        }
+    }
+    // set the value
+    err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_SENSORMODE, temp);
+    if( failed(err) )
+    {
+        manage_error( deb, "Cannot set sensor mode", err, 
+                      "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_SENSORMODE, VALUE=%d", static_cast<int>(temp));
+        THROW_HW_ERROR(Error) << "Cannot set sensor mode";
+    }
+
+    manage_trace( deb, "Changed sensor mode", DCAMERR_NONE, NULL, "%f", temp);
+}
+
+//-----------------------------------------------------------------------------
+/// This property allows you to get the image pixel type. 
+//-----------------------------------------------------------------------------
+enum Camera::Pixel_Type Camera::getPixelType()
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    double  temp;
+    Camera::Pixel_Type pixel_type = Camera::Pixel_Type::Pixel_Type_Not_Supported;
+    
+    if(getStatus() == CameraThread::Ready)
+    {
+        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_IMAGE_PIXELTYPE, &temp );        
+        if( failed(err) )
+        {
+            manage_trace( deb, "Unable to retrieve the pixel type", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
+
+            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
+            {
+                THROW_HW_ERROR(Error) << "Unable to retrieve the pixel type";
+            }
+        }    
+        else
+        {
+            int result = static_cast<int>(temp);
+            switch(result)
+            {
+                case DCAM_PIXELTYPE_MONO8 : pixel_type = Pixel_Type_Mono8  ; break;
+                case DCAM_PIXELTYPE_MONO16: pixel_type = Pixel_Type_Mono16 ; break;
+                case DCAM_PIXELTYPE_RGB24 : pixel_type = Pixel_Type_RGB24  ; break;
+                case DCAM_PIXELTYPE_RGB48 : pixel_type = Pixel_Type_RGB48  ; break;
+                case DCAM_PIXELTYPE_BGR24 : pixel_type = Pixel_Type_BGR24  ; break;
+                case DCAM_PIXELTYPE_BGR48 : pixel_type = Pixel_Type_BGR48  ; break;
+                default:
+                    manage_trace( deb, "The read pixel type is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
+            }
+        }
+    }
+    return pixel_type;
+}
+
+//-----------------------------------------------------------------------------
+/// This property allows you to choose pixel data format.
+//-----------------------------------------------------------------------------
+void Camera::setPixelType(enum Pixel_Type in_pixel_type)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_TRACE() << "Camera::setPixelType(" << (int)in_pixel_type << ")";
+    
+    DCAMERR err;
+    double temp;
+    switch(in_pixel_type)
+    {
+        case Pixel_Type_Mono8 : temp = static_cast<double>(DCAM_PIXELTYPE_MONO8) ; break;
+        case Pixel_Type_Mono16: temp = static_cast<double>(DCAM_PIXELTYPE_MONO16); break;
+        case Pixel_Type_RGB24 : temp = static_cast<double>(DCAM_PIXELTYPE_RGB24) ; break;
+        case Pixel_Type_RGB48 : temp = static_cast<double>(DCAM_PIXELTYPE_RGB48) ; break;
+        case Pixel_Type_BGR24 : temp = static_cast<double>(DCAM_PIXELTYPE_BGR24) ; break;
+        case Pixel_Type_BGR48 : temp = static_cast<double>(DCAM_PIXELTYPE_BGR48) ; break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the pixel type",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_pixel_type is unknown %d",
+                                static_cast<int>(in_pixel_type));
+
+            THROW_HW_ERROR(Error) << "Unable to set the sensor mode";
+        }
+    }
+    // set the value
+    err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_IMAGE_PIXELTYPE, temp);
+    if( failed(err) )
+    {
+        manage_error( deb, "Cannot set pixel type", err, 
+                      "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_IMAGE_PIXELTYPE, VALUE=%d", static_cast<int>(temp));
+        THROW_HW_ERROR(Error) << "Cannot set pixel type";
+    }
+
+    manage_trace( deb, "Changed pixel type to ", DCAMERR_NONE, NULL, "%f", temp);
+}
+
+// Scan Mode
+//-----------------------------------------------------------------------------
+/// This property allows you to get the scan mode of the camera. 
+//-----------------------------------------------------------------------------
+enum Camera::Scan_Mode Camera::getScanMode()
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    double  temp;
+    Camera::Scan_Mode scan_mode = Camera::Scan_Mode::Scan_Mode_Not_Supported;
+    
+    if(getStatus() == CameraThread::Ready)
+    {
+        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_READOUTSPEED, &temp );       
+        if( failed(err) )
+        {
+            manage_trace( deb, "Unable to retrieve the sensor mode", err, "dcamprop_getvalue - DCAM_IDPROP_READOUTSPEED");
+
+            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
+            {
+                THROW_HW_ERROR(Error) << "Unable to retrieve the sensor mode";
+            }
+        }    
+        else
+        {
+            int mode = static_cast<int>(temp);
+            switch(mode)
+            {
+                case DCAMPROP_READOUTSPEED__SLOWEST : scan_mode = Scan_Mode_Ultra_Quiet ; break;
+                case DCAMPROP_READOUTSPEED__FASTEST : scan_mode = Scan_Mode_Standard    ; break;
+                default:
+                    manage_trace( deb, "The read sensor mode is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_READOUTSPEED");
+            }
+        }
+    }
+    return scan_mode;
+}
+
+//-----------------------------------------------------------------------------
+/// This property allows you to specify the sensor mode of the camera.
+//-----------------------------------------------------------------------------
+void Camera::setScanMode(enum Scan_Mode in_scan_mode)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_TRACE() << "Camera::setScanMode(" << (int)in_scan_mode << ")";
+
+    DCAMERR err;
+    double temp;
+    switch(in_scan_mode)
+    {
+        case Scan_Mode_Ultra_Quiet : temp = static_cast<double>(DCAMPROP_READOUTSPEED__SLOWEST); break;
+        case Scan_Mode_Standard    : temp = static_cast<double>(DCAMPROP_READOUTSPEED__FASTEST); break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the scan mode",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_scan_mode is unknown %d",
+                                static_cast<int>(in_scan_mode));
+
+            THROW_HW_ERROR(Error) << "Unable to set the scan mode";
+        }
+    }
+    // set the value
+    err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_READOUTSPEED, temp);
+    if( failed(err) )
+    {
+        manage_error( deb, "Cannot set scan mode", err, 
+                      "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_READOUTSPEED, VALUE=%d", static_cast<int>(temp));
+        THROW_HW_ERROR(Error) << "Cannot set scan mode";
+    }
+
+    manage_trace( deb, "Changed scan mode to", DCAMERR_NONE, NULL, "%f", temp);
+}
+
+//=============================================================================
+// INPUT TRIGGER ACTIVE
+//=============================================================================
+//-----------------------------------------------------------------------------
+/// Return the input trigger active of given channel by the current detector
+//-----------------------------------------------------------------------------
+enum Camera::Input_Trigger_Active Camera::getInputTriggerActive()
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    enum Input_Trigger_Active active = Camera::Input_Trigger_Active_Not_Supported;
+
+    //Get the trigger active value
+    double tmp = 99;
+    err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERACTIVE, &tmp);
+    if(!failed(err))
+    {                
+        int32 value = static_cast<int32>(tmp);
+        switch(value) 
+        {
+            case DCAMPROP_TRIGGERACTIVE__EDGE        : active = Camera::Input_Trigger_Active_Edge       ; break;
+            case DCAMPROP_TRIGGERACTIVE__LEVEL       : active = Camera::Input_Trigger_Active_Level      ; break;
+            case DCAMPROP_TRIGGERACTIVE__SYNCREADOUT : active = Camera::Input_Trigger_Active_SyncReadout; break;
+            default: break; // result will be Input_Trigger_Active_Not_Supported
+        }
+    } //else TODO
+
+    return active;
+}
+
+/* Refactoring
+int Camera::getChannelTrigger(int channel, TRIGGER trigger)
+{
+    switch(trigger.type) 
+    {
+        case TRIGGER::TYPE::INPUT:
+        {
+            switch(trigger.name)
+            {
+                case TRIGGER::NAME::ACTIVE: 
+                    return getInputTriggerActive(channel); 
+                case TRIGGER::NAME::POLARITY: 
+                    return getInputTriggerPolarity(channel);
+                default: break;
+            }
+        } break;
+        case TRIGGER::TYPE::OUTPUT:
+        {
+           switch(trigger.name)
+            {
+                case TRIGGER::NAME::DELAY: 
+                    return getOutputTriggerDelay(channel); 
+                case TRIGGER::NAME::KIND: 
+                    return getOutputTriggerKind(channel); 
+                case TRIGGER::NAME::POLARITY: 
+                    return getOutputTriggerPolarity(channel); 
+                case TRIGGER::NAME::SOURCE: 
+                return getOutputTriggerSource(channel); 
+                default: break;
+            }
+         } break;
+         default : break;
+    }
+    return -1;
+}
+
+void Camera::setChannelTrigger(int channel, int trigger_enum, TRIGGER trigger)
+{
+    switch(trigger.type) 
+    {
+        case TRIGGER::TYPE::INPUT:
+        {
+            switch(trigger.name)
+            {
+                case TRIGGER::NAME::ACTIVE: setInputTriggerActive(channel, trigger_enum); break;
+                case TRIGGER::NAME::POLARITY: setInputTriggerPolarity(channel, trigger_enum); break;
+                default: break;
+            }
+        } break;
+        case TRIGGER::TYPE::OUTPUT:
+        {
+           switch(trigger.name)
+            {
+                case TRIGGER::NAME::DELAY: setOutputTriggerDelay(channel, trigger_enum); break;
+                case TRIGGER::NAME::KIND: setOutputTriggerKind(channel, trigger_enum); break;
+                case TRIGGER::NAME::POLARITY: setOutputTriggerPolarity(channel, trigger_enum); break;
+                case TRIGGER::NAME::SOURCE: setOutputTriggerSource(channel, trigger_enum); break;
+                default: break;
+            }
+         } break;
+    }
+}
+*/
+
+//-----------------------------------------------------------------------------
+/// Set the input trigger active of given channel by the current detector
+//-----------------------------------------------------------------------------
+void Camera::setInputTriggerActive(enum Input_Trigger_Active in_input_trig_active)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_TRACE() << "Camera::setInputTriggerActive(" << (int)in_input_trig_active << ")";
+
+    DCAMERR  err ;
+    int      active;
+
+    switch(in_input_trig_active)
+    {
+        case Input_Trigger_Active_Edge :
+            active = DCAMPROP_TRIGGERACTIVE__EDGE;
+            break;
+        case Input_Trigger_Active_Level:
+            active = DCAMPROP_TRIGGERACTIVE__LEVEL;
+            break;
+        case Input_Trigger_Active_SyncReadout:
+            active = DCAMPROP_TRIGGERACTIVE__SYNCREADOUT;
+            break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the Input trigger Active",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_input_trig_active is unknown %d",
+                                static_cast<int>(in_input_trig_active));
+
+            THROW_HW_ERROR(Error) << "Unable to set the Input trigger Active.";
+        }
+    }
+
+    // set the active
+    err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_TRIGGERACTIVE, static_cast<double>(active) );
+    if( failed(err) )
+    {
+        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
+        {
+            manage_trace( deb, "Unable to set the Input trigger active",
+                                err, 
+                               "dcamprop_setvalue",
+                               "DCAM_IDPROP_TRIGGERACTIVE %d",
+                               active);
+
+            THROW_HW_ERROR(Error) << "Unable to set the Input trigger active.";
+        }
+    }
+}
+
+//=============================================================================
+// INPUT TRIGGER POLARITY
+//=============================================================================
+//-----------------------------------------------------------------------------
+/// Return the input trigger polarity of given channel by the current detector
+//-----------------------------------------------------------------------------
+enum Camera::Input_Trigger_Polarity Camera::getInputTriggerPolarity()
+{
+    DEB_MEMBER_FUNCT();
+
+    DCAMERR err;
+    enum Input_Trigger_Polarity polarity = Camera::Input_Trigger_Polarity_Not_Supported;
+
+    //Get the channel kind value
+    double tmp = 99;
+    err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERPOLARITY, &tmp);
+    if(!failed(err))
+    {                
+        int32 value = static_cast<int32>(tmp);
+        switch(value) 
+        {
+            case DCAMPROP_TRIGGERPOLARITY__NEGATIVE : polarity = Camera::Input_Trigger_Polarity_Negative ; break;
+            case DCAMPROP_TRIGGERPOLARITY__POSITIVE : polarity = Camera::Input_Trigger_Polarity_Positive ; break;
+            default: break; // result will be Input_Trigger_Active_Not_Supported
+        }
+    } //else TODO
+    
+    return polarity;
+}
+
+//-----------------------------------------------------------------------------
+/// Set the input trigger polarity of given channel by the current detector
+//-----------------------------------------------------------------------------
+void Camera::setInputTriggerPolarity(enum Input_Trigger_Polarity in_input_trig_polarity)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_TRACE() << "Camera::setInputTriggerPolarity(" << (int)in_input_trig_polarity << ")";
+
+    DCAMERR  err ;
+    int      polarity;
+
+    switch(in_input_trig_polarity)
+    {
+        case Input_Trigger_Polarity_Negative :
+            polarity = DCAMPROP_TRIGGERPOLARITY__NEGATIVE;
+            break;
+        case Input_Trigger_Polarity_Positive:
+            polarity = DCAMPROP_TRIGGERPOLARITY__POSITIVE;
+            break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the Input trigger Polarity",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_input_trig_polarity is unknown %d",
+                                static_cast<int>(in_input_trig_polarity));
+
+            THROW_HW_ERROR(Error) << "Unable to set the Input trigger Polarity";
+        }
+    }
+
+    //Compute property ID for given channel
+    int32 property_id = DCAM_IDPROP_TRIGGERPOLARITY;
+
+    // set the polarity
+    err = dcamprop_setvalue( m_camera_handle, property_id, static_cast<double>(polarity) );
+    if( failed(err) )
+    {
+        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
+        {
+            manage_trace( deb, "Unable to set the Input trigger polarity",
+                                err, 
+                               "dcamprop_setvalue",
+                               "DCAM_IDPROP_TRIGGERPOLARITY %d",
+                               polarity);
+
+            THROW_HW_ERROR(Error) << "Unable to set the Input trigger Polarity";
+        }
+    }
+}
+
+//=============================================================================
+// OUTPUT TRIGGER DELAY
+//=============================================================================
+//-----------------------------------------------------------------------------
+/// Return the output trigger delay of given channel by the current detector
+//-----------------------------------------------------------------------------
+double Camera::getOutputTriggerDelay(int channel)
+{
+    DEB_MEMBER_FUNCT();
+
+    //DEB_TRACE() << " Camera::Output_Trigger_Delay Camera::getOutputTriggerDelay(int channel) : ..."; 
+
+    DCAMERR err;
+    double delayArraySize = 0;
+    double delay = 0.0;
+
+    // get property attribute that contains the Kind (that may be an array)
+    DCAMPROP_ATTR    basepropattr;
+    memset(&basepropattr, 0, sizeof(basepropattr));
+    basepropattr.cbSize = sizeof(basepropattr);
+    basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_DELAY;
+    
+    err = dcamprop_getattr(m_camera_handle, &basepropattr);
+    if( failed(err) )
+    {
+        manage_trace( deb, "Unable to retrieve the output trigger delay attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_DELAY");
+
+        if((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
+        {
+            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger delay attribute";
+        }
+    }    
+    else
+    {
+        //Get the ARRAYELEMENT size to ensure that the given channel is reachable
+        err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &delayArraySize);
+        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", delayArraySize = " << delayArraySize;
+        if (!failed(err) && channel < delayArraySize)
+        {
+            //Get the channel delay value
+            double tmp = 99;
+            err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
+
+            if(!failed(err))
+            {
+                delay = tmp;
+            } //else TODO
+        }
+    }
+    
+    return delay;
+}
+
+//=============================================================================
+// OUTPUT TRIGGER SOURCE
+//=============================================================================
+//-----------------------------------------------------------------------------
+/// Return the output trigger source of given channel by the current detector
+//-----------------------------------------------------------------------------
+enum Camera::Output_Trigger_Source Camera::getOutputTriggerSource(int channel)
+{
+    DEB_MEMBER_FUNCT();
+
+    //DEB_TRACE() << " Camera::Output_Trigger_Kind Camera::getOutputTriggerSource(int channel) : ..."; 
+
+    DCAMERR err;
+    double sourceArraySize = 0;
+    enum Output_Trigger_Source source = Camera::Output_Trigger_Source_Not_Supported;
+
+    // get property attribute that contains the Kind (that may be an array)
+    DCAMPROP_ATTR    basepropattr;
+    memset(&basepropattr, 0, sizeof(basepropattr));
+    basepropattr.cbSize = sizeof(basepropattr);
+    basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_SOURCE;
+    err = dcamprop_getattr(m_camera_handle, &basepropattr);
+
+    if( failed(err) )
+    {
+        manage_trace( deb, "Unable to retrieve the output trigger source attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_SOURCE");
+
+        if((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
+        {
+            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger source attribute";
+        }
+    }    
+    else
+    {
+        //Get the ARRAYELEMENT size to ensure that the given channel is reachable
+        err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &sourceArraySize);
+        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", sourceArraySize = " << sourceArraySize;       
+        if (!failed(err) && channel < sourceArraySize)
+        {
+            //Get the channel kind value
+            double tmp = 99;
+            err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
+
+            if(!failed(err))
+            {                
+                int32 value = static_cast<int32>(tmp);
+
+                switch(value) 
+                {
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE   : source = Camera::Output_Trigger_Source_Global_Exposure ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND : source = Camera::Output_Trigger_Source_Readout_End     ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC      : source = Camera::Output_Trigger_Source_VSync           ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC      : source = Camera::Output_Trigger_Source_HSync           ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER    : source = Camera::Output_Trigger_Source_Trigger         ; break;
+                    default: break; // result will be Output_Trigger_Source_Not_Supported
+
+                }
+            } //else TODO
+        }
+    }
+    
+    return source;
+}
+
 //=============================================================================
 // OUTPUT TRIGGER KIND
 //=============================================================================
@@ -3009,7 +3767,7 @@ enum Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel)
 {
     DEB_MEMBER_FUNCT();
 
-    DEB_TRACE() << " Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel) : ..."; 
+    //DEB_TRACE() << " Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel) : ..."; 
 
     DCAMERR err;
     double kindArraySize = 0;
@@ -3035,6 +3793,7 @@ enum Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel)
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &kindArraySize);
+        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", kindArraySize = " << kindArraySize;       
         if (!failed(err) && channel < kindArraySize)
         {
             //Get the channel kind value
@@ -3072,7 +3831,7 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
 {
     DEB_MEMBER_FUNCT();
 
-    DEB_TRACE() << "Camera::getOutputTriggerPolarity(int channel) : channel = " << channel;
+    //DEB_TRACE() << "Camera::getOutputTriggerPolarity(int channel) : channel = " << channel;
 
     DCAMERR err;
     double polarityArraySize = 0;
@@ -3085,7 +3844,7 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
     basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_POLARITY;
     err = dcamprop_getattr(m_camera_handle, &basepropattr);
 
-    DEB_TRACE() << " Camera::getOutputTriggerPolarity(int channel) : get property attribute done";
+    //DEB_TRACE() << " Camera::getOutputTriggerPolarity(int channel) : get property attribute done";
 
     if (failed(err))
     {
@@ -3100,6 +3859,7 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &polarityArraySize);
+        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", polarityArraySize = " << polarityArraySize;       
         if (!failed(err) && channel < polarityArraySize)
         {
             //Get the channel polarity value
@@ -3129,6 +3889,123 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
 }
 
 //=============================================================================
+// OUTPUT TRIGGER DELAY
+//=============================================================================
+//-----------------------------------------------------------------------------
+// Set the output trigger delay of given channel by the current detector
+// This property allows you to specify the delay of output trigger if DCAM_IDPROP_OUTPUTTRIGGER_ACTIVE is set to "EDGE".
+// Control is leaved to device to check the value.
+//-----------------------------------------------------------------------------
+void Camera::setOutputTriggerDelay(int channel, double in_output_trig_delay)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(in_output_trig_delay);
+
+    DEB_TRACE() << "Camera::setOutputTriggerKind(" << channel << ", " << (int)in_output_trig_delay << ")";
+
+    DCAMERR  err ;
+
+    //Compute property ID for given channel
+    int32 property_id = 0;
+    int32 array_base = 0;
+    int32 step_element = 0;
+
+    getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_DELAY, array_base, step_element);
+    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+    property_id = array_base + step_element * channel;
+
+    // set the kind
+    err = dcamprop_setvalue( m_camera_handle, property_id, in_output_trig_delay );
+
+    if( failed(err) )
+    {
+        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
+        {
+            manage_trace( deb, "Unable to set the Output trigger Delay",
+                                err, 
+                               "dcamprop_setvalue",
+                               "DCAM_IDPROP_OUTPUTTRIGGER_DELAY[%d] %d",
+                               channel,
+                               in_output_trig_delay);
+
+            THROW_HW_ERROR(Error) << "Unable to set the Output trigger delay";
+        }
+    }
+}
+
+//=============================================================================
+// OUTPUT TRIGGER SOURCE
+//=============================================================================
+//-----------------------------------------------------------------------------
+/// Set the output trigger source of given channel by the current detector
+//-----------------------------------------------------------------------------
+void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_output_trig_source)
+{
+    DEB_MEMBER_FUNCT();
+    DEB_PARAM() << DEB_VAR1(in_output_trig_source);
+
+    DEB_TRACE() << "Camera::setOutputTriggerSource(" << channel << ", " << (int)in_output_trig_source << ")";
+
+    DCAMERR  err ;
+    int      source;
+
+    switch(in_output_trig_source)
+    {
+        case Output_Trigger_Source_Global_Exposure :
+            source = DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE;
+            break;
+        case Output_Trigger_Source_Readout_End:
+            source = DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND;
+            break;
+        case Output_Trigger_Source_VSync:
+            source = DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC;
+            break;
+        case Output_Trigger_Source_HSync:
+            source = DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC;
+            break;
+        case Output_Trigger_Source_Trigger:
+            source = DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER;
+            break;
+        default:
+        {
+            manage_error( deb,  "Unable to set the Output trigger Source",
+                                DCAMERR_NONE, 
+                                "",
+                                "in_output_trig_source is unknown %d",
+                                static_cast<int>(in_output_trig_source));
+
+            THROW_HW_ERROR(Error) << "Unable to set the Output trigger source";
+        }
+    }
+
+    //Compute property ID for given channel
+    int32 property_id = 0;
+    int32 array_base = 0;
+    int32 step_element = 0;
+
+    getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_SOURCE, array_base, step_element);
+    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+    property_id = array_base + step_element * channel;
+
+    // set the kind
+    err = dcamprop_setvalue( m_camera_handle, property_id, static_cast<double>(source) );
+    if( failed(err) )
+    {
+        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
+        {
+            manage_trace( deb, "Unable to set the Output trigger source",
+                                err, 
+                               "dcamprop_setvalue",
+                               "DCAM_IDPROP_OUTPUTTRIGGER_SOURCE[%d] %d",
+                               channel,
+                               source);
+
+            THROW_HW_ERROR(Error) << "Unable to set the Output trigger source";
+        }
+    }
+}
+
+//=============================================================================
 // OUTPUT TRIGGER KIND
 //=============================================================================
 //-----------------------------------------------------------------------------
@@ -3139,7 +4016,7 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
     DEB_MEMBER_FUNCT();
     DEB_PARAM() << DEB_VAR1(in_output_trig_kind);
 
-    DEB_TRACE() << "Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_output_trig_kind)";
+    DEB_TRACE() << "Camera::setOutputTriggerKind(" << channel << ", " << (int)in_output_trig_kind << ")";
 
     DCAMERR  err ;
     int      kind;
@@ -3185,7 +4062,7 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_KIND, array_base, step_element);
-
+    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * channel;
 
     // set the kind
@@ -3216,8 +4093,8 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
 void Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigger_Polarity in_output_trig_polarity)
 {
     DEB_MEMBER_FUNCT();
-    DEB_TRACE() << "Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigger_Polarity in_output_trig_polarity) : ...";
-    DEB_PARAM() << DEB_VAR1(in_output_trig_polarity);
+    DEB_TRACE() << "Camera::setOutputTriggerPolarity(" << in_channel << ", " << (int)in_output_trig_polarity << ")";
+    //DEB_PARAM() << DEB_VAR1(in_output_trig_polarity);
 
     DCAMERR err;
     int     polarity;
@@ -3247,7 +4124,7 @@ void Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigge
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_POLARITY, array_base, step_element);
-
+    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * in_channel;
 
     //set the polarity
@@ -3298,12 +4175,12 @@ std::string Camera::getAllParameters()
 
     int32 parameter_id = 0; /* parameter ID */
     int32 last_id = 0;
-	
+    
     char name[ 64 ];
-	DCAMERR err;
-	
-	do
-	{
+    DCAMERR err;
+    
+    do
+    {
         err = dcamprop_getnextid(m_camera_handle, &parameter_id, DCAMPROP_OPTION_SUPPORT);
         if(failed(err) || last_id == parameter_id)
         {
@@ -3320,7 +4197,7 @@ std::string Camera::getAllParameters()
 
         res << name << " = "<< param;
         
-	} while(!failed(err) && parameter_id != 0);
+    } while(!failed(err) && parameter_id != 0);
 
     return res.str();
 }
@@ -3332,7 +4209,7 @@ std::string Camera::getParameter(std::string parameter_name)
     DEB_MEMBER_FUNCT();
 
     std::stringstream res;
-	DCAMERR err;
+    DCAMERR err;
 
     double value;
 
@@ -3355,7 +4232,7 @@ void Camera::setParameter(std::string parameter_name, double value)
 {
     DEB_MEMBER_FUNCT();
 
-	DCAMERR err;
+    DCAMERR err;
     int parameter_id = m_map_parameters[parameter_name];
     err = dcamprop_setvalue(m_camera_handle, parameter_id, value);
     if(failed(err))
@@ -3388,12 +4265,12 @@ void Camera::initParametersMap()
     std::stringstream res;
 
     int32 parameter_id; /* parameter ID */
-	
-	parameter_id = 0;
-	DCAMERR err;
-	
-	do
-	{
+    
+    parameter_id = 0;
+    DCAMERR err;
+    
+    do
+    {
         err = dcamprop_getnextid(m_camera_handle, &parameter_id, DCAMPROP_OPTION_SUPPORT);
 
         if(failed(err))
@@ -3403,7 +4280,7 @@ void Camera::initParametersMap()
 
         mapIdParameter(parameter_id);
         
-	} while(!failed(err) && parameter_id != 0);
+    } while(!failed(err) && parameter_id != 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -3413,7 +4290,7 @@ void Camera::mapIdParameter(int32 parameter_id)
     DEB_MEMBER_FUNCT();
 
     std::stringstream res;
-	DCAMERR err;
+    DCAMERR err;
 
     char name[ 64 ];
  

--- a/src/HamamatsuCamera.cpp
+++ b/src/HamamatsuCamera.cpp
@@ -232,27 +232,27 @@ Camera::~Camera()
 // ICATHALES-587
 void Camera::initDetectorModel()
 {
-    DEB_MEMBER_FUNCT();
-    
+	DEB_MEMBER_FUNCT();
+	
     char model_str[MAX_PATH];
-    DCAMERR err;
+	DCAMERR err;
 
-    DCAMDEV_STRING  param;
-    memset( &param, 0, sizeof(param) );
-    param.size      = sizeof(param);
-    param.text      = model_str;
-    param.textbytes = sizeof(model_str);
-    param.iString   = DCAM_IDSTR_MODEL;
-    
-    err = dcamdev_getstring( m_camera_handle, &param );
+    DCAMDEV_STRING	param;
+	memset( &param, 0, sizeof(param) );
+	param.size		= sizeof(param);
+	param.text		= model_str;
+	param.textbytes	= sizeof(model_str);
+	param.iString	= DCAM_IDSTR_MODEL;
+	
+	err = dcamdev_getstring( m_camera_handle, &param );
     if (failed(err))
     {
         manage_error(deb, "Cannot get detector model", err, "dcamdev_getstring", "IDSTR=DCAM_IDSTR_MODEL");
     }
     else
-    {
+	{
         m_detector_model = model_str;
-        DEB_TRACE() << "m_detector_model = " << m_detector_model;
+		DEB_TRACE() << "m_detector_model = " << m_detector_model;
     }
 }
 
@@ -1507,7 +1507,7 @@ short int Camera::getReadoutSpeedFromLabel(const std::string & in_readout_speed_
     short int   readout_speed = READOUTSPEED_NORMAL_VALUE;
     std::string label         = in_readout_speed_label;
 
-    transform(label.begin(), label.end(), label.begin(), ::toupper);
+	transform(label.begin(), label.end(), label.begin(), ::toupper);
 
     if (label == READOUTSPEED_NORMAL_NAME)
     {
@@ -1519,11 +1519,11 @@ short int Camera::getReadoutSpeedFromLabel(const std::string & in_readout_speed_
         readout_speed = READOUTSPEED_SLOW_VALUE;
     }
     else
-    {           
-        string user_msg;
+	{			
+		string user_msg;
         user_msg = string("Available Readout speeds are:\n- ") + string(READOUTSPEED_NORMAL_NAME) + string("\n- ") + string(READOUTSPEED_SLOW_NAME);
         THROW_HW_ERROR(Error) << user_msg.c_str();
-    }
+	}
 
     return readout_speed;
 }
@@ -3143,30 +3143,30 @@ HwEventCtrlObj* Camera::getEventCtrlObj()
 // get property attribute
 long Camera::getNbMaxChannels(int32 idProp)
 {
-    DEB_MEMBER_FUNCT();
-    
+	DEB_MEMBER_FUNCT();
+	
     long nbOfChannels = 1;
     // get property attribute
-    DCAMPROP_ATTR   basepropattr;
+    DCAMPROP_ATTR	basepropattr;
     memset( &basepropattr, 0, sizeof(basepropattr) );
-    basepropattr.cbSize = sizeof(basepropattr);
-    
-    if (idProp == -1)
-        basepropattr.iProp = DCAM_IDPROP__CHANNEL;
-    else
-        basepropattr.iProp = idProp;
-    
+    basepropattr.cbSize	= sizeof(basepropattr);
+	
+	if (idProp == -1)
+		basepropattr.iProp = DCAM_IDPROP__CHANNEL;
+	else
+		basepropattr.iProp = idProp;
+	
     DCAMERR err;
     err = dcamprop_getattr( m_camera_handle, &basepropattr );
     if( !failed(err) )
     {
         nbOfChannels = basepropattr.nMaxChannel;
-        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : Number of channels = " << nbOfChannels;
-        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_ArrayBase = " << basepropattr.iProp_ArrayBase;
-        DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_NumberOfElement = " << basepropattr.iProp_NumberOfElement;
+		DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : Number of channels = " << nbOfChannels;
+		DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_ArrayBase = " << basepropattr.iProp_ArrayBase;
+		DEB_TRACE() << "getNbMaxChannels(" << idProp << ") : iProp_NumberOfElement = " << basepropattr.iProp_NumberOfElement;
     }
     else
-    {
+	{
         manage_trace( deb, "Unable to get attr number of channels", err, "dcamprop_getattr - DCAM_IDPROP__CHANNEL");
     }
     return nbOfChannels;
@@ -3184,33 +3184,27 @@ enum Camera::Sensor_Mode Camera::getSensorMode()
     double  temp;
     Camera::Sensor_Mode sensor_mode = Camera::Sensor_Mode::Sensor_Mode_Not_Supported;
     
-    if(getStatus() == CameraThread::Ready)
-    {
-        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_SENSORMODE, &temp );      
-        if( failed(err) )
-        {
-            manage_trace( deb, "Unable to retrieve the sensor mode", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
-
-            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
-            {
-                THROW_HW_ERROR(Error) << "Unable to retrieve the sensor mode";
-            }
-        }    
-        else
-        {
-            int mode = static_cast<int>(temp);
-            switch(mode)
-            {
-                case DCAMPROP_SENSORMODE__AREA          : sensor_mode = Sensor_Mode_Area            ; break;
-                case DCAMPROP_SENSORMODE__LINE          : sensor_mode = Sensor_Mode_Line            ; break;
-                case DCAMPROP_SENSORMODE__TDI           : sensor_mode = Sensor_Mode_TDI             ; break;
-                case DCAMPROP_SENSORMODE__TDI_EXTENDED  : sensor_mode = Sensor_Mode_TDI_Extented    ; break;
-                case DCAMPROP_SENSORMODE__PROGRESSIVE   : sensor_mode = Sensor_Mode_Progressive     ; break;
-                default:
-                    manage_trace( deb, "The read sensor mode is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
-            }
-        }
-    }
+	err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_SENSORMODE, &temp );      
+	if( failed(err) )
+	{
+		manage_trace( deb, "Unable to retrieve the sensor mode", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
+		THROW_HW_ERROR(Error) << "Unable to retrieve the sensor mode";
+	}    
+	else
+	{
+		int32 mode = static_cast<int32>(temp);
+		switch(mode)
+		{
+			case DCAMPROP_SENSORMODE__AREA          : sensor_mode = Sensor_Mode_Area            ; break;
+			case DCAMPROP_SENSORMODE__LINE          : sensor_mode = Sensor_Mode_Line            ; break;
+			case DCAMPROP_SENSORMODE__TDI           : sensor_mode = Sensor_Mode_TDI             ; break;
+			case DCAMPROP_SENSORMODE__TDI_EXTENDED  : sensor_mode = Sensor_Mode_TDI_Extented    ; break;
+			case DCAMPROP_SENSORMODE__PROGRESSIVE   : sensor_mode = Sensor_Mode_Progressive     ; break;
+			default:
+				manage_trace( deb, "The read sensor mode is unknown!", err, "dcamprop_getvalue - DCAM_IDPROP_SENSORMODE");
+		}
+		//DEB_TRACE() << "getSensorMode() - temp=" << temp << ", mode=" << mode;
+	}
     return sensor_mode;
 }
 
@@ -3248,10 +3242,11 @@ void Camera::setSensorMode(enum Sensor_Mode in_sensor_mode)
     {
         manage_error( deb, "Cannot set sensor mode", err, 
                       "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_SENSORMODE, VALUE=%d", static_cast<int>(temp));
-        THROW_HW_ERROR(Error) << "Cannot set sensor mode";
+		THROW_HW_ERROR(Error) << "Cannot set sensor mode";
+
     }
 
-    manage_trace( deb, "Changed sensor mode", DCAMERR_NONE, NULL, "%f", temp);
+    manage_trace( deb, "Changed sensor mode", DCAMERR_NONE, NULL, "%d", (int)in_sensor_mode );
 }
 
 //-----------------------------------------------------------------------------
@@ -3265,34 +3260,28 @@ enum Camera::Pixel_Type Camera::getPixelType()
     double  temp;
     Camera::Pixel_Type pixel_type = Camera::Pixel_Type::Pixel_Type_Not_Supported;
     
-    if(getStatus() == CameraThread::Ready)
-    {
-        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_IMAGE_PIXELTYPE, &temp );        
-        if( failed(err) )
-        {
-            manage_trace( deb, "Unable to retrieve the pixel type", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
-
-            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
-            {
-                THROW_HW_ERROR(Error) << "Unable to retrieve the pixel type";
-            }
-        }    
-        else
-        {
-            int result = static_cast<int>(temp);
-            switch(result)
-            {
-                case DCAM_PIXELTYPE_MONO8 : pixel_type = Pixel_Type_Mono8  ; break;
-                case DCAM_PIXELTYPE_MONO16: pixel_type = Pixel_Type_Mono16 ; break;
-                case DCAM_PIXELTYPE_RGB24 : pixel_type = Pixel_Type_RGB24  ; break;
-                case DCAM_PIXELTYPE_RGB48 : pixel_type = Pixel_Type_RGB48  ; break;
-                case DCAM_PIXELTYPE_BGR24 : pixel_type = Pixel_Type_BGR24  ; break;
-                case DCAM_PIXELTYPE_BGR48 : pixel_type = Pixel_Type_BGR48  ; break;
-                default:
-                    manage_trace( deb, "The read pixel type is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
-            }
-        }
-    }
+	err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_IMAGE_PIXELTYPE, &temp );        
+	if( failed(err) )
+	{
+		manage_trace( deb, "Unable to retrieve the pixel type", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
+		THROW_HW_ERROR(Error) << "Unable to retrieve the pixel type";
+	}    
+	else
+	{
+		int32 result = static_cast<int32>(temp);
+		switch(result)
+		{
+			case DCAM_PIXELTYPE_MONO8 : pixel_type = Pixel_Type_Mono8  ; break;
+			case DCAM_PIXELTYPE_MONO16: pixel_type = Pixel_Type_Mono16 ; break;
+			case DCAM_PIXELTYPE_RGB24 : pixel_type = Pixel_Type_RGB24  ; break;
+			case DCAM_PIXELTYPE_RGB48 : pixel_type = Pixel_Type_RGB48  ; break;
+			case DCAM_PIXELTYPE_BGR24 : pixel_type = Pixel_Type_BGR24  ; break;
+			case DCAM_PIXELTYPE_BGR48 : pixel_type = Pixel_Type_BGR48  ; break;
+			default:
+				manage_trace( deb, "Unknown read pixel type", err, "dcamprop_getvalue - DCAM_IDPROP_IMAGE_PIXELTYPE");
+		}
+		//DEB_TRACE() << "getPixelType() - temp=" << temp << ", result=" << result;
+	}
     return pixel_type;
 }
 
@@ -3303,7 +3292,7 @@ void Camera::setPixelType(enum Pixel_Type in_pixel_type)
 {
     DEB_MEMBER_FUNCT();
     DEB_TRACE() << "Camera::setPixelType(" << (int)in_pixel_type << ")";
-    
+	
     DCAMERR err;
     double temp;
     switch(in_pixel_type)
@@ -3313,16 +3302,16 @@ void Camera::setPixelType(enum Pixel_Type in_pixel_type)
         case Pixel_Type_RGB24 : temp = static_cast<double>(DCAM_PIXELTYPE_RGB24) ; break;
         case Pixel_Type_RGB48 : temp = static_cast<double>(DCAM_PIXELTYPE_RGB48) ; break;
         case Pixel_Type_BGR24 : temp = static_cast<double>(DCAM_PIXELTYPE_BGR24) ; break;
-        case Pixel_Type_BGR48 : temp = static_cast<double>(DCAM_PIXELTYPE_BGR48) ; break;
+		case Pixel_Type_BGR48 : temp = static_cast<double>(DCAM_PIXELTYPE_BGR48) ; break;
         default:
         {
-            manage_error( deb,  "Unable to set the pixel type",
+            manage_error( deb,  "Unknown pixel type set value",
                                 DCAMERR_NONE, 
                                 "",
                                 "in_pixel_type is unknown %d",
                                 static_cast<int>(in_pixel_type));
 
-            THROW_HW_ERROR(Error) << "Unable to set the sensor mode";
+            THROW_HW_ERROR(Error) << "Unable to set the pixel type";
         }
     }
     // set the value
@@ -3333,84 +3322,7 @@ void Camera::setPixelType(enum Pixel_Type in_pixel_type)
                       "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_IMAGE_PIXELTYPE, VALUE=%d", static_cast<int>(temp));
         THROW_HW_ERROR(Error) << "Cannot set pixel type";
     }
-
-    manage_trace( deb, "Changed pixel type to ", DCAMERR_NONE, NULL, "%f", temp);
-}
-
-// Scan Mode
-//-----------------------------------------------------------------------------
-/// This property allows you to get the scan mode of the camera. 
-//-----------------------------------------------------------------------------
-enum Camera::Scan_Mode Camera::getScanMode()
-{
-    DEB_MEMBER_FUNCT();
-
-    DCAMERR err;
-    double  temp;
-    Camera::Scan_Mode scan_mode = Camera::Scan_Mode::Scan_Mode_Not_Supported;
-    
-    if(getStatus() == CameraThread::Ready)
-    {
-        err = dcamprop_getvalue( m_camera_handle, DCAM_IDPROP_READOUTSPEED, &temp );       
-        if( failed(err) )
-        {
-            manage_trace( deb, "Unable to retrieve the sensor mode", err, "dcamprop_getvalue - DCAM_IDPROP_READOUTSPEED");
-
-            if((err != DCAMERR_INVALIDPROPERTYID)&&(err != DCAMERR_NOTSUPPORT))
-            {
-                THROW_HW_ERROR(Error) << "Unable to retrieve the sensor mode";
-            }
-        }    
-        else
-        {
-            int mode = static_cast<int>(temp);
-            switch(mode)
-            {
-                case DCAMPROP_READOUTSPEED__SLOWEST : scan_mode = Scan_Mode_Ultra_Quiet ; break;
-                case DCAMPROP_READOUTSPEED__FASTEST : scan_mode = Scan_Mode_Standard    ; break;
-                default:
-                    manage_trace( deb, "The read sensor mode is incoherent!", err, "dcamprop_getvalue - DCAM_IDPROP_READOUTSPEED");
-            }
-        }
-    }
-    return scan_mode;
-}
-
-//-----------------------------------------------------------------------------
-/// This property allows you to specify the sensor mode of the camera.
-//-----------------------------------------------------------------------------
-void Camera::setScanMode(enum Scan_Mode in_scan_mode)
-{
-    DEB_MEMBER_FUNCT();
-    DEB_TRACE() << "Camera::setScanMode(" << (int)in_scan_mode << ")";
-
-    DCAMERR err;
-    double temp;
-    switch(in_scan_mode)
-    {
-        case Scan_Mode_Ultra_Quiet : temp = static_cast<double>(DCAMPROP_READOUTSPEED__SLOWEST); break;
-        case Scan_Mode_Standard    : temp = static_cast<double>(DCAMPROP_READOUTSPEED__FASTEST); break;
-        default:
-        {
-            manage_error( deb,  "Unable to set the scan mode",
-                                DCAMERR_NONE, 
-                                "",
-                                "in_scan_mode is unknown %d",
-                                static_cast<int>(in_scan_mode));
-
-            THROW_HW_ERROR(Error) << "Unable to set the scan mode";
-        }
-    }
-    // set the value
-    err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_READOUTSPEED, temp);
-    if( failed(err) )
-    {
-        manage_error( deb, "Cannot set scan mode", err, 
-                      "dcamprop_setvalue", "IDPROP=DCAM_IDPROP_READOUTSPEED, VALUE=%d", static_cast<int>(temp));
-        THROW_HW_ERROR(Error) << "Cannot set scan mode";
-    }
-
-    manage_trace( deb, "Changed scan mode to", DCAMERR_NONE, NULL, "%f", temp);
+    manage_trace( deb, "Changed pixel type to ", DCAMERR_NONE, NULL, "%d", (int)in_pixel_type);
 }
 
 //=============================================================================
@@ -3426,43 +3338,43 @@ enum Camera::Input_Trigger_Active Camera::getInputTriggerActive()
     DCAMERR err;
     enum Input_Trigger_Active active = Camera::Input_Trigger_Active_Not_Supported;
 
-    //Get the trigger active value
-    double tmp = 99;
-    err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERACTIVE, &tmp);
-    if(!failed(err))
-    {                
-        int32 value = static_cast<int32>(tmp);
-        switch(value) 
-        {
-            case DCAMPROP_TRIGGERACTIVE__EDGE        : active = Camera::Input_Trigger_Active_Edge       ; break;
-            case DCAMPROP_TRIGGERACTIVE__LEVEL       : active = Camera::Input_Trigger_Active_Level      ; break;
-            case DCAMPROP_TRIGGERACTIVE__SYNCREADOUT : active = Camera::Input_Trigger_Active_SyncReadout; break;
-            default: break; // result will be Input_Trigger_Active_Not_Supported
-        }
-    } //else TODO
+	//Get the trigger active value
+	double tmp = 99;
+	err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERACTIVE, &tmp);
+	if(!failed(err))
+	{                
+		int32 value = static_cast<int32>(tmp);
+		switch(value) 
+		{
+			case DCAMPROP_TRIGGERACTIVE__EDGE        : active = Camera::Input_Trigger_Active_Edge       ; break;
+			case DCAMPROP_TRIGGERACTIVE__LEVEL       : active = Camera::Input_Trigger_Active_Level      ; break;
+			case DCAMPROP_TRIGGERACTIVE__SYNCREADOUT : active = Camera::Input_Trigger_Active_SyncReadout; break;
+			default: break; // result will be Input_Trigger_Active_Not_Supported
+		}
+	} //else TODO
 
     return active;
 }
 
 /* Refactoring
-int Camera::getChannelTrigger(int channel, TRIGGER trigger)
+int Camera::getChannelTrigger(TRIGGER trigger, int channel)
 {
     switch(trigger.type) 
     {
         case TRIGGER::TYPE::INPUT:
         {
-            switch(trigger.name)
+            switch(trigger.id)
             {
                 case TRIGGER::NAME::ACTIVE: 
-                    return getInputTriggerActive(channel); 
+                    return getInputTriggerActive(); 
                 case TRIGGER::NAME::POLARITY: 
-                    return getInputTriggerPolarity(channel);
+                    return getInputTriggerPolarity();
                 default: break;
             }
         } break;
         case TRIGGER::TYPE::OUTPUT:
         {
-           switch(trigger.name)
+           switch(trigger.id)
             {
                 case TRIGGER::NAME::DELAY: 
                     return getOutputTriggerDelay(channel); 
@@ -3480,27 +3392,27 @@ int Camera::getChannelTrigger(int channel, TRIGGER trigger)
     return -1;
 }
 
-void Camera::setChannelTrigger(int channel, int trigger_enum, TRIGGER trigger)
+void Camera::setChannelTrigger(TRIGGER trigger, int trigger_value, int channel)
 {
     switch(trigger.type) 
     {
         case TRIGGER::TYPE::INPUT:
         {
-            switch(trigger.name)
+            switch(trigger.id)
             {
-                case TRIGGER::NAME::ACTIVE: setInputTriggerActive(channel, trigger_enum); break;
-                case TRIGGER::NAME::POLARITY: setInputTriggerPolarity(channel, trigger_enum); break;
+                case TRIGGER::NAME::ACTIVE: setInputTriggerActive(trigger_value); break;
+                case TRIGGER::NAME::POLARITY: setInputTriggerPolarity(trigger_value); break;
                 default: break;
             }
         } break;
         case TRIGGER::TYPE::OUTPUT:
         {
-           switch(trigger.name)
+           switch(trigger.id)
             {
-                case TRIGGER::NAME::DELAY: setOutputTriggerDelay(channel, trigger_enum); break;
-                case TRIGGER::NAME::KIND: setOutputTriggerKind(channel, trigger_enum); break;
-                case TRIGGER::NAME::POLARITY: setOutputTriggerPolarity(channel, trigger_enum); break;
-                case TRIGGER::NAME::SOURCE: setOutputTriggerSource(channel, trigger_enum); break;
+                case TRIGGER::NAME::DELAY: setOutputTriggerDelay(channel, trigger_value); break;
+                case TRIGGER::NAME::KIND: setOutputTriggerKind(channel, trigger_value); break;
+                case TRIGGER::NAME::POLARITY: setOutputTriggerPolarity(channel, trigger_value); break;
+                case TRIGGER::NAME::SOURCE: setOutputTriggerSource(channel, trigger_value); break;
                 default: break;
             }
          } break;
@@ -3532,7 +3444,7 @@ void Camera::setInputTriggerActive(enum Input_Trigger_Active in_input_trig_activ
             break;
         default:
         {
-            manage_error( deb,  "Unable to set the Input trigger Active",
+            manage_error( deb,  "Unknown Input trigger Active set value",
                                 DCAMERR_NONE, 
                                 "",
                                 "in_input_trig_active is unknown %d",
@@ -3546,16 +3458,12 @@ void Camera::setInputTriggerActive(enum Input_Trigger_Active in_input_trig_activ
     err = dcamprop_setvalue( m_camera_handle, DCAM_IDPROP_TRIGGERACTIVE, static_cast<double>(active) );
     if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Input trigger active",
-                                err, 
-                               "dcamprop_setvalue",
-                               "DCAM_IDPROP_TRIGGERACTIVE %d",
-                               active);
-
-            THROW_HW_ERROR(Error) << "Unable to set the Input trigger active.";
-        }
+		manage_trace( deb, "Unable to set the Input trigger active",
+							err, 
+						   "dcamprop_setvalue",
+						   "DCAM_IDPROP_TRIGGERACTIVE %d",
+						   active);
+        THROW_HW_ERROR(Error) << "Unable to set the Input trigger active.";
     }
 }
 
@@ -3572,19 +3480,19 @@ enum Camera::Input_Trigger_Polarity Camera::getInputTriggerPolarity()
     DCAMERR err;
     enum Input_Trigger_Polarity polarity = Camera::Input_Trigger_Polarity_Not_Supported;
 
-    //Get the channel kind value
-    double tmp = 99;
-    err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERPOLARITY, &tmp);
-    if(!failed(err))
-    {                
-        int32 value = static_cast<int32>(tmp);
-        switch(value) 
-        {
-            case DCAMPROP_TRIGGERPOLARITY__NEGATIVE : polarity = Camera::Input_Trigger_Polarity_Negative ; break;
-            case DCAMPROP_TRIGGERPOLARITY__POSITIVE : polarity = Camera::Input_Trigger_Polarity_Positive ; break;
-            default: break; // result will be Input_Trigger_Active_Not_Supported
-        }
-    } //else TODO
+	//Get the channel kind value
+	double tmp = 99;
+	err = dcamprop_getvalue(m_camera_handle, DCAM_IDPROP_TRIGGERPOLARITY, &tmp);
+	if(!failed(err))
+	{                
+		int32 value = static_cast<int32>(tmp);
+		switch(value) 
+		{
+			case DCAMPROP_TRIGGERPOLARITY__NEGATIVE : polarity = Camera::Input_Trigger_Polarity_Negative ; break;
+			case DCAMPROP_TRIGGERPOLARITY__POSITIVE : polarity = Camera::Input_Trigger_Polarity_Positive ; break;
+			default: break; // result will be Input_Trigger_Active_Not_Supported
+		}
+	} //else TODO
     
     return polarity;
 }
@@ -3610,7 +3518,7 @@ void Camera::setInputTriggerPolarity(enum Input_Trigger_Polarity in_input_trig_p
             break;
         default:
         {
-            manage_error( deb,  "Unable to set the Input trigger Polarity",
+            manage_error( deb,  "Unknown Input trigger Polarity set value",
                                 DCAMERR_NONE, 
                                 "",
                                 "in_input_trig_polarity is unknown %d",
@@ -3621,22 +3529,18 @@ void Camera::setInputTriggerPolarity(enum Input_Trigger_Polarity in_input_trig_p
     }
 
     //Compute property ID for given channel
-    int32 property_id = DCAM_IDPROP_TRIGGERPOLARITY;
+	int32 property_id = DCAM_IDPROP_TRIGGERPOLARITY;
 
     // set the polarity
     err = dcamprop_setvalue( m_camera_handle, property_id, static_cast<double>(polarity) );
     if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Input trigger polarity",
-                                err, 
-                               "dcamprop_setvalue",
-                               "DCAM_IDPROP_TRIGGERPOLARITY %d",
-                               polarity);
-
-            THROW_HW_ERROR(Error) << "Unable to set the Input trigger Polarity";
-        }
+		manage_trace( deb, "Unable to set the Input trigger polarity",
+							err, 
+						   "dcamprop_setvalue",
+						   "DCAM_IDPROP_TRIGGERPOLARITY %d",
+						   polarity);
+        THROW_HW_ERROR(Error) << "Unable to set the Input trigger Polarity";
     }
 }
 
@@ -3656,33 +3560,28 @@ double Camera::getOutputTriggerDelay(int channel)
     double delayArraySize = 0;
     double delay = 0.0;
 
-    // get property attribute that contains the Kind (that may be an array)
+    // get property attribute that contains the Delay (that may be an array)
     DCAMPROP_ATTR    basepropattr;
     memset(&basepropattr, 0, sizeof(basepropattr));
     basepropattr.cbSize = sizeof(basepropattr);
     basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_DELAY;
-    
+	
     err = dcamprop_getattr(m_camera_handle, &basepropattr);
     if( failed(err) )
     {
         manage_trace( deb, "Unable to retrieve the output trigger delay attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_DELAY");
-
-        if((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
-        {
-            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger delay attribute";
-        }
+        THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger delay attribute";
     }    
     else
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &delayArraySize);
-        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", delayArraySize = " << delayArraySize;
+		//DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", delayArraySize = " << delayArraySize;
         if (!failed(err) && channel < delayArraySize)
         {
             //Get the channel delay value
             double tmp = 99;
             err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
-
             if(!failed(err))
             {
                 delay = tmp;
@@ -3703,58 +3602,60 @@ enum Camera::Output_Trigger_Source Camera::getOutputTriggerSource(int channel)
 {
     DEB_MEMBER_FUNCT();
 
-    //DEB_TRACE() << " Camera::Output_Trigger_Kind Camera::getOutputTriggerSource(int channel) : ..."; 
+    //DEB_TRACE() << " Camera::Output_Trigger_Source Camera::getOutputTriggerSource(int channel) : ..."; 
 
     DCAMERR err;
     double sourceArraySize = 0;
-    enum Output_Trigger_Source source = Camera::Output_Trigger_Source_Not_Supported;
+    enum Output_Trigger_Source result = Camera::Output_Trigger_Source_Not_Supported;
 
     // get property attribute that contains the Kind (that may be an array)
     DCAMPROP_ATTR    basepropattr;
     memset(&basepropattr, 0, sizeof(basepropattr));
     basepropattr.cbSize = sizeof(basepropattr);
     basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_SOURCE;
+	
     err = dcamprop_getattr(m_camera_handle, &basepropattr);
-
     if( failed(err) )
     {
         manage_trace( deb, "Unable to retrieve the output trigger source attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_SOURCE");
-
-        if((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
-        {
-            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger source attribute";
-        }
+        THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger source attribute";
     }    
     else
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &sourceArraySize);
-        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", sourceArraySize = " << sourceArraySize;       
+		//DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", sourceArraySize = " << sourceArraySize;		
         if (!failed(err) && channel < sourceArraySize)
         {
             //Get the channel kind value
             double tmp = 99;
             err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
-
             if(!failed(err))
             {                
-                int32 value = static_cast<int32>(tmp);
-
-                switch(value) 
+                int32 casted_val = static_cast<int32>(tmp);
+                switch(casted_val) 
                 {
-                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE   : source = Camera::Output_Trigger_Source_Global_Exposure ; break;
-                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND : source = Camera::Output_Trigger_Source_Readout_End     ; break;
-                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC      : source = Camera::Output_Trigger_Source_VSync           ; break;
-                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC      : source = Camera::Output_Trigger_Source_HSync           ; break;
-                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER    : source = Camera::Output_Trigger_Source_Trigger         ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__EXPOSURE   : result = Camera::Output_Trigger_Source_Global_Exposure ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__READOUTEND : result = Camera::Output_Trigger_Source_Readout_End     ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__VSYNC      : result = Camera::Output_Trigger_Source_VSync           ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__HSYNC      : result = Camera::Output_Trigger_Source_HSync           ; break;
+                    case DCAMPROP_OUTPUTTRIGGER_SOURCE__TRIGGER    : result = Camera::Output_Trigger_Source_Trigger         ; break;
                     default: break; // result will be Output_Trigger_Source_Not_Supported
-
                 }
-            } //else TODO
+				//DEB_TRACE() << "getOutputTriggerSource(" << channel+1 << ") : tmp=" << tmp << " => source=" << source;
+            } 
+			else
+			{
+				manage_trace( deb, "TRIGGER SOURCE - dcamprop_getvalue : Unable to retrieve the output trigger source attribute", err, "");
+			}
         }
+		else if (failed(err))
+		{
+			DEB_TRACE() << "TRIGGER SOURCE - dcamprop_getvalue : Condition channel[" << channel << "] < sourceArraySize[" << sourceArraySize << "] not satisfied";
+		}
     }
     
-    return source;
+    return result;
 }
 
 //=============================================================================
@@ -3778,32 +3679,26 @@ enum Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel)
     memset(&basepropattr, 0, sizeof(basepropattr));
     basepropattr.cbSize = sizeof(basepropattr);
     basepropattr.iProp = DCAM_IDPROP_OUTPUTTRIGGER_KIND;
+	
     err = dcamprop_getattr(m_camera_handle, &basepropattr);
-
     if( failed(err) )
     {
         manage_trace( deb, "Unable to retrieve the output trigger kind attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_KIND");
-
-        if((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
-        {
-            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger kind attribute";
-        }
+        THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger kind attribute";
     }    
     else
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &kindArraySize);
-        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", kindArraySize = " << kindArraySize;       
+		//DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", kindArraySize = " << kindArraySize;		
         if (!failed(err) && channel < kindArraySize)
         {
             //Get the channel kind value
             double tmp = 99;
             err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
-
             if(!failed(err))
             {                
                 int32 value = static_cast<int32>(tmp);
-
                 switch(value) 
                 {
                     case DCAMPROP_OUTPUTTRIGGER_KIND__LOW              : kind = Camera::Output_Trigger_Kind_Low             ; break;
@@ -3812,7 +3707,6 @@ enum Camera::Output_Trigger_Kind Camera::getOutputTriggerKind(int channel)
                     case DCAMPROP_OUTPUTTRIGGER_KIND__TRIGGERREADY     : kind = Camera::Output_Trigger_Kind_TriggerReady    ; break;
                     case DCAMPROP_OUTPUTTRIGGER_KIND__HIGH             : kind = Camera::Output_Trigger_Kind_High            ; break;
                     default: break; // result will be Output_Trigger_Kind_Not_Supported
-
                 }
             } //else TODO
         }
@@ -3849,27 +3743,21 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
     if (failed(err))
     {
         manage_trace(deb, "Unable to retrieve the output trigger kind attribute", err, "dcamprop_getattr - DCAM_IDPROP_OUTPUTTRIGGER_KIND");
-
-        if ((err != DCAMERR_INVALIDPROPERTYID) && (err != DCAMERR_NOTSUPPORT))
-        {
-            THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger kind attribute";
-        }
+        THROW_HW_ERROR(Error) << "Unable to retrieve the output trigger kind attribute";
     }
     else
     {
         //Get the ARRAYELEMENT size to ensure that the given channel is reachable
         err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp_NumberOfElement, &polarityArraySize);
-        //DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", polarityArraySize = " << polarityArraySize;       
+		//DEB_TRACE() << "NumberOfElement = " << basepropattr.iProp_NumberOfElement << ", polarityArraySize = " << polarityArraySize;		
         if (!failed(err) && channel < polarityArraySize)
         {
             //Get the channel polarity value
             double tmp = 99;
             err = dcamprop_getvalue(m_camera_handle, basepropattr.iProp + channel * basepropattr.iPropStep_Element, &tmp);
-
             if (!failed(err))
             {
                 int32 value = static_cast<int32>(tmp);
-
                 switch (value)
                 {
                 case DCAMPROP_OUTPUTTRIGGER_POLARITY__NEGATIVE:
@@ -3899,9 +3787,8 @@ enum Camera::Output_Trigger_Polarity Camera::getOutputTriggerPolarity(int channe
 void Camera::setOutputTriggerDelay(int channel, double in_output_trig_delay)
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(in_output_trig_delay);
-
-    DEB_TRACE() << "Camera::setOutputTriggerKind(" << channel << ", " << (int)in_output_trig_delay << ")";
+    //DEB_PARAM() << DEB_VAR1(in_output_trig_delay);
+    DEB_TRACE() << "Camera::setOutputTriggerKind(Channel=" << channel+1 << ", value=" << (int)in_output_trig_delay << ")";
 
     DCAMERR  err ;
 
@@ -3911,25 +3798,21 @@ void Camera::setOutputTriggerDelay(int channel, double in_output_trig_delay)
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_DELAY, array_base, step_element);
-    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+	//DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * channel;
 
     // set the kind
     err = dcamprop_setvalue( m_camera_handle, property_id, in_output_trig_delay );
-
     if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Output trigger Delay",
-                                err, 
-                               "dcamprop_setvalue",
-                               "DCAM_IDPROP_OUTPUTTRIGGER_DELAY[%d] %d",
-                               channel,
-                               in_output_trig_delay);
+		manage_trace( deb, "Unable to set the Output trigger Delay",
+					err, 
+				   "dcamprop_setvalue",
+				   "DCAM_IDPROP_OUTPUTTRIGGER_DELAY[%d] %d",
+				   channel+1,
+				   in_output_trig_delay);
+        THROW_HW_ERROR(Error) << "Unable to set the Output trigger delay";
 
-            THROW_HW_ERROR(Error) << "Unable to set the Output trigger delay";
-        }
     }
 }
 
@@ -3939,12 +3822,11 @@ void Camera::setOutputTriggerDelay(int channel, double in_output_trig_delay)
 //-----------------------------------------------------------------------------
 /// Set the output trigger source of given channel by the current detector
 //-----------------------------------------------------------------------------
-void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_output_trig_source)
+void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_output_trig_source, bool raise_ex)
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(in_output_trig_source);
-
-    DEB_TRACE() << "Camera::setOutputTriggerSource(" << channel << ", " << (int)in_output_trig_source << ")";
+    //DEB_PARAM() << DEB_VAR1(in_output_trig_source);
+    DEB_TRACE() << "Camera::setOutputTriggerSource(Channel=" << channel+1 << ", value=" << (int)in_output_trig_source << ")";
 
     DCAMERR  err ;
     int      source;
@@ -3968,7 +3850,7 @@ void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_o
             break;
         default:
         {
-            manage_error( deb,  "Unable to set the Output trigger Source",
+            manage_error( deb,  "Unknown Output trigger Source set value",
                                 DCAMERR_NONE, 
                                 "",
                                 "in_output_trig_source is unknown %d",
@@ -3984,24 +3866,23 @@ void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_o
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_SOURCE, array_base, step_element);
-    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+	//DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * channel;
 
     // set the kind
     err = dcamprop_setvalue( m_camera_handle, property_id, static_cast<double>(source) );
     if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Output trigger source",
-                                err, 
-                               "dcamprop_setvalue",
-                               "DCAM_IDPROP_OUTPUTTRIGGER_SOURCE[%d] %d",
-                               channel,
-                               source);
-
-            THROW_HW_ERROR(Error) << "Unable to set the Output trigger source";
-        }
+		manage_trace( deb, "Unable to set the Output trigger source",
+							err, 
+						   "dcamprop_setvalue",
+						   "DCAM_IDPROP_OUTPUTTRIGGER_SOURCE[%d] %d",
+						   channel+1,
+						   source);
+		if (err == DCAMERR_INVALIDVALUE && raise_ex)
+		{
+			THROW_HW_ERROR(Error) << "Unable to set the Output trigger source";
+		}
     }
 }
 
@@ -4014,9 +3895,8 @@ void Camera::setOutputTriggerSource(int channel, enum Output_Trigger_Source in_o
 void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_output_trig_kind)
 {
     DEB_MEMBER_FUNCT();
-    DEB_PARAM() << DEB_VAR1(in_output_trig_kind);
-
-    DEB_TRACE() << "Camera::setOutputTriggerKind(" << channel << ", " << (int)in_output_trig_kind << ")";
+    //DEB_PARAM() << DEB_VAR1(in_output_trig_kind);
+    DEB_TRACE() << "Camera::setOutputTriggerKind(Channel=" << channel+1 << ", value=" << (int)in_output_trig_kind << ")";
 
     DCAMERR  err ;
     int      kind;
@@ -4047,7 +3927,7 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
     }
     else
     {
-        manage_error( deb,  "Unable to set the Output trigger Kind",
+        manage_error( deb,  "Unknown Output trigger Kind set value",
                             DCAMERR_NONE, 
                             "",
                             "in_output_trig_kind is unknown %d",
@@ -4062,25 +3942,21 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_KIND, array_base, step_element);
-    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+	//DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * channel;
 
     // set the kind
     err = dcamprop_setvalue( m_camera_handle,property_id , static_cast<double>(kind) );
-
     if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Output trigger Kind",
-                                err, 
-                               "dcamprop_setvalue",
-                               "DCAM_IDPROP_OUTPUTTRIGGER_KIND[%d] %d",
-                               channel,
-                               kind);
+		manage_trace( deb, "Unable to set the Output trigger Kind",
+						   err, 
+						   "dcamprop_setvalue",
+						   "DCAM_IDPROP_OUTPUTTRIGGER_KIND[%d] %d",
+						   channel+1,
+						   kind);
+        THROW_HW_ERROR(Error) << "Unable to set the Output trigger Kind";
 
-            THROW_HW_ERROR(Error) << "Unable to set the Output trigger Kind";
-        }
     }
 }
 
@@ -4093,7 +3969,7 @@ void Camera::setOutputTriggerKind(int channel, enum Output_Trigger_Kind in_outpu
 void Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigger_Polarity in_output_trig_polarity)
 {
     DEB_MEMBER_FUNCT();
-    DEB_TRACE() << "Camera::setOutputTriggerPolarity(" << in_channel << ", " << (int)in_output_trig_polarity << ")";
+    DEB_TRACE() << "Camera::setOutputTriggerPolarity(Channel=" << in_channel+1 << ", value=" << (int)in_output_trig_polarity << ")";
     //DEB_PARAM() << DEB_VAR1(in_output_trig_polarity);
 
     DCAMERR err;
@@ -4109,7 +3985,7 @@ void Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigge
     }
     else
     {
-        manage_error( deb,  "Unable to set the Output trigger Polarity", 
+        manage_error( deb,  "Unknown Output trigger Polarity set value", 
                             DCAMERR_NONE, 
                             "",
                             "in_output_trig_polarity is unknown %d",
@@ -4124,25 +4000,20 @@ void Camera::setOutputTriggerPolarity(int in_channel, enum Camera::Output_Trigge
     int32 step_element = 0;
 
     getPropertyData(DCAM_IDPROP_OUTPUTTRIGGER_POLARITY, array_base, step_element);
-    //DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
+	//DEB_TRACE() << "array_base = " << array_base << ", step_element = " << step_element;
     property_id = array_base + step_element * in_channel;
 
     //set the polarity
     err = dcamprop_setvalue(m_camera_handle, property_id, static_cast<double>(polarity) );
-
-     if( failed(err) )
+    if( failed(err) )
     {
-        if((err == DCAMERR_INVALIDPROPERTYID) || (err == DCAMERR_NOTSUPPORT))
-        {
-            manage_trace( deb, "Unable to set the Output trigger Polarity", 
-                                err, 
-                                "dcamprop_setvalue",
-                                "DCAM_IDPROP_OUTPUTTRIGGER_POLARITY[%d] %d", 
-                                in_channel,
-                                polarity);
-
-            THROW_HW_ERROR(Error) << "Unable to set the Output trigger Polarity";
-        }
+		manage_trace( deb, "Unable to set the Output trigger Polarity", 
+							err, 
+							"dcamprop_setvalue",
+							"DCAM_IDPROP_OUTPUTTRIGGER_POLARITY[%d] %d", 
+							in_channel+1,
+							polarity);
+        THROW_HW_ERROR(Error) << "Unable to set the Output trigger Polarity";
     }
 }
 
@@ -4175,12 +4046,12 @@ std::string Camera::getAllParameters()
 
     int32 parameter_id = 0; /* parameter ID */
     int32 last_id = 0;
-    
+	
     char name[ 64 ];
-    DCAMERR err;
-    
-    do
-    {
+	DCAMERR err;
+	
+	do
+	{
         err = dcamprop_getnextid(m_camera_handle, &parameter_id, DCAMPROP_OPTION_SUPPORT);
         if(failed(err) || last_id == parameter_id)
         {
@@ -4197,7 +4068,7 @@ std::string Camera::getAllParameters()
 
         res << name << " = "<< param;
         
-    } while(!failed(err) && parameter_id != 0);
+	} while(!failed(err) && parameter_id != 0);
 
     return res.str();
 }
@@ -4209,7 +4080,7 @@ std::string Camera::getParameter(std::string parameter_name)
     DEB_MEMBER_FUNCT();
 
     std::stringstream res;
-    DCAMERR err;
+	DCAMERR err;
 
     double value;
 
@@ -4232,7 +4103,7 @@ void Camera::setParameter(std::string parameter_name, double value)
 {
     DEB_MEMBER_FUNCT();
 
-    DCAMERR err;
+	DCAMERR err;
     int parameter_id = m_map_parameters[parameter_name];
     err = dcamprop_setvalue(m_camera_handle, parameter_id, value);
     if(failed(err))
@@ -4265,12 +4136,12 @@ void Camera::initParametersMap()
     std::stringstream res;
 
     int32 parameter_id; /* parameter ID */
-    
-    parameter_id = 0;
-    DCAMERR err;
-    
-    do
-    {
+	
+	parameter_id = 0;
+	DCAMERR err;
+	
+	do
+	{
         err = dcamprop_getnextid(m_camera_handle, &parameter_id, DCAMPROP_OPTION_SUPPORT);
 
         if(failed(err))
@@ -4280,7 +4151,7 @@ void Camera::initParametersMap()
 
         mapIdParameter(parameter_id);
         
-    } while(!failed(err) && parameter_id != 0);
+	} while(!failed(err) && parameter_id != 0);
 }
 
 //-----------------------------------------------------------------------------
@@ -4290,7 +4161,7 @@ void Camera::mapIdParameter(int32 parameter_id)
     DEB_MEMBER_FUNCT();
 
     std::stringstream res;
-    DCAMERR err;
+	DCAMERR err;
 
     char name[ 64 ];
  


### PR DESCRIPTION
Doter le pluggin hamamatsu de la possibilité de fonctionner quel que soit le model du device. Il s'agit de détecter d'abord le model du device. Si ce model est Orca QUEST, on active les attributs suivants en plus des attributs pré-existants :

Sensor mode 
Pixel Type 
Scan Mode (Readout noise)
Input Trigger Active et Polarity
Output Trigger  Delay, Source, Kind et Polarity
