### PR TITLE
[ISACDEVIND-13] Added sensorMode property support & corrected readoutSpeed labels

### DIFF
--- a/include/HamamatsuCamera.h
+++ b/include/HamamatsuCamera.h
@@ -251,12 +251,16 @@ namespace lima
         std::string getReadoutSpeedLabel(void);
         void        setReadoutSpeedLabel(const std::string & in_readout_speed_label);
 
+        std::string getSensorModeLabel(void);
+        void        setSensorModeLabel(const std::string & in_sensor_mode_label);
+
         bool isSensorTemperatureSupported(void);
         bool isTemperatureStatusSupported(void);
         bool isCoolerModeSupported       (void);
         bool isCoolerStatusSupported     (void);
         bool isHighDynamicRangeSupported (void);
         bool isReadoutSpeedSupported     (void);
+        bool isSensorModeSupported       (void);
 
         /**
         *\fn  getAllParameters
@@ -295,6 +299,12 @@ namespace lima
 
         std::string getReadoutSpeedLabelFromValue(const short int in_readout_speed) const;
         short int   getReadoutSpeedFromLabel     (const std::string & in_readout_speed_label) const;
+
+        short int getSensorMode(void) const;
+		void      setSensorMode(const short int sensor_mode); ///< [in]  new sensor mode
+
+        std::string getSensorModeLabelFromValue(const short int in_sensor_mode) const;
+        short int   getSensorModeFromLabel     (const std::string & in_sensor_mode_label) const;
 
         /**
         *\fn  getPropertyData

--- a/src/HamamatsuCamera.cpp
+++ b/src/HamamatsuCamera.cpp
@@ -70,8 +70,8 @@ const string Camera::g_trace_little_line_separator = "--------------------------
 
 #define READOUTSPEED_SLOW_VALUE     1
 #define READOUTSPEED_NORMAL_VALUE   2
-#define READOUTSPEED_SLOW_NAME      "SLOW"
-#define READOUTSPEED_NORMAL_NAME    "NORMAL"
+#define READOUTSPEED_SLOW_NAME      "ULTRA QUIET"
+#define READOUTSPEED_NORMAL_NAME    "STANDARD"
 
 //-----------------------------------------------------------------------------
 ///  Ctor


### PR DESCRIPTION
Added the sensorMode property for Hamamatsu cameras, with the following values being now supported :
- AREA
- PROGRESSIVE

Renamed labels for the readoutSpeed property :
- NORMAL -> STANDARD
- SLOW -> ULTRA QUIET

Linked pull request for specific device : [#102](https://github.com/soleil-ica/Lima-tango-cpp/pull/102)
